### PR TITLE
feat(grpc): Add grpc client that doesn't depend on fx

### DIFF
--- a/fxtracing/tracing.go
+++ b/fxtracing/tracing.go
@@ -102,13 +102,15 @@ func NewTracerProvider(lc fx.Lifecycle, conf TracingConfig, logger *zap.Logger) 
 			KeyFile:    tracingConf.KeyFile,
 			RootCAFile: tracingConf.RootCAFile,
 		}
-		creds, err := fxgrpc.MakeClientTLS(
-			lc,
+		creds, r, err := fxgrpc.MakeClientTLS(
 			clientConf,
 			logger,
 		)
 		if err != nil {
 			return nil, err
+		}
+		if r != nil {
+			lc.Append(fx.Hook{OnStart: r.Start, OnStop: r.Stop})
 		}
 		opts = append(opts, otlpgrpc.WithTLSCredentials(creds))
 	}


### PR DESCRIPTION
This PR adds a `NewGrpcClient` function that tries to offer as many of the conveniences as the fx module, without any fx dependencies.

The usecase is for dynamically generated, short-lived, clients: fx assumes there will be only 1, or a very small number of instances of a particular module.
This doesn't play nice with how our replication works: we need to query zookeeper to figure out which nodes we should connect to, to pull blobs. We don't know at system initialization which nodes we need to connect to.
The new function allows us to create ad hoc clients, while still retrieving the logger and middleware from the fx app and get all the nice TLS handling that was implemented.

I've tried to share as much code as possible, to prevent feature drift, but this does lead to some weird stuff like functions with ternary returns. These are confined to the module though, users don't have to deal with it in the public api.

[sc-33074]