### PR TITLE
fix(pprof): Ensure Enabled is honored

### DIFF
--- a/fxpprof/pprof.go
+++ b/fxpprof/pprof.go
@@ -93,7 +93,7 @@ func InitPprofProfiler(server *http.Server) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof", pprof.Index)
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)


### PR DESCRIPTION
The `Enabled` config parameter was ignored.

I also took the opportunity to use the new `Annotate` functionality, which simplifies the function signatures and pushes the fx specific labeling in the Module definition (where it arguably fits better)