### PR TITLE
fix(mtls): For mTLS GetClientCertificate needs to be set

### DIFF
--- a/fxcert-reloader/cert-reloader.go
+++ b/fxcert-reloader/cert-reloader.go
@@ -48,7 +48,7 @@ type CertReloader struct {
 // GetCertificate returns the currently loaded keypair
 // It is meant to be passed into a tls.Config
 // If reloading fails, this method will return the last valid keypair
-func (c *CertReloader) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func (c *CertReloader) GetCertificate() (*tls.Certificate, error) {
 	// Naively return our cert
 	// Maybe we can try to load if cert is nil
 	return c.cert, nil

--- a/fxcert-reloader/cert-reloader_test.go
+++ b/fxcert-reloader/cert-reloader_test.go
@@ -2,7 +2,6 @@ package fxcert_reloader
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"os"
 	"testing"
@@ -87,7 +86,7 @@ func TestNewCertReloader(t *testing.T) {
 		reloader, err := NewCertReloader(conf, zap.NewNop())
 		assert.NoError(t, err)
 		if assert.NotNil(t, reloader) {
-			cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+			cert, err := reloader.GetCertificate()
 			assert.NoError(t, err)
 			if assert.NotNil(t, cert) {
 				pCert, err := x509.ParseCertificate(cert.Certificate[0])
@@ -137,7 +136,7 @@ func TestCertReloader(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Assert that we emit the initial cert first
-		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		cert, err := reloader.GetCertificate()
 		assert.NoError(t, err)
 		pCert, err := x509.ParseCertificate(cert.Certificate[0])
 		assert.NoError(t, err)
@@ -159,7 +158,7 @@ func TestCertReloader(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 
 		// Assert that we emit the second cert
-		cert2, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		cert2, err := reloader.GetCertificate()
 		assert.NoError(t, err)
 		pCert2, err := x509.ParseCertificate(cert2.Certificate[0])
 		assert.NoError(t, err)
@@ -203,7 +202,7 @@ func TestCertReloader(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Assert that we emit the initial cert first
-		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		cert, err := reloader.GetCertificate()
 		assert.NoError(t, err)
 		pCert, err := x509.ParseCertificate(cert.Certificate[0])
 		assert.NoError(t, err)
@@ -221,7 +220,7 @@ func TestCertReloader(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 
 		// Assert that we still emit the initial cert
-		cert2, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		cert2, err := reloader.GetCertificate()
 		assert.NoError(t, err)
 		pCert2, err := x509.ParseCertificate(cert2.Certificate[0])
 		assert.NoError(t, err)
@@ -266,7 +265,7 @@ func TestCertReloader(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Assert that we emit the initial cert first
-		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		cert, err := reloader.GetCertificate()
 		assert.NoError(t, err)
 		pCert, err := x509.ParseCertificate(cert.Certificate[0])
 		assert.NoError(t, err)
@@ -283,7 +282,7 @@ func TestCertReloader(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 
 		// Assert that we still emit the initial cert
-		cert2, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		cert2, err := reloader.GetCertificate()
 		assert.NoError(t, err)
 		pCert2, err := x509.ParseCertificate(cert2.Certificate[0])
 		assert.NoError(t, err)

--- a/fxcert-reloader/example_test.go
+++ b/fxcert-reloader/example_test.go
@@ -25,7 +25,7 @@ func ExampleNewCertReloader() {
 	}
 	defer reloader.Stop(context.Background()) //nolint:errcheck
 
-	cfg := &tls.Config{GetCertificate: reloader.GetCertificate}
+	cfg := &tls.Config{GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) { return reloader.GetCertificate() }}
 
 	listener, err := tls.Listen("tcp", ":2000", cfg)
 	if err != nil {

--- a/fxgrpc/grpc-client.go
+++ b/fxgrpc/grpc-client.go
@@ -141,7 +141,7 @@ func MakeClientTLS(c GrpcClientConfig, logger *zap.Logger) (credentials.Transpor
 		}
 
 		tlsConf := &tls.Config{
-			GetCertificate: r.GetCertificate,
+			GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) { return r.GetCertificate() },
 		}
 
 		if conf.RootCAFile != "" {

--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -109,7 +109,7 @@ type GrpcServerParams struct {
 
 func makeServerTLS(r *reloader.CertReloader, clientCAFile string) (credentials.TransportCredentials, error) {
 	tlsConf := &tls.Config{
-		GetCertificate: r.GetCertificate,
+		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) { return r.GetCertificate() },
 	}
 
 	if clientCAFile != "" {

--- a/fxhttp/http.go
+++ b/fxhttp/http.go
@@ -73,7 +73,7 @@ func GetCertReloaderConfig(conf ServerConfig) *reloader.CertReloaderConfig {
 // TODO: refactor the grpc server version in terms of this one
 func makeTLS(r *reloader.CertReloader, clientCAFile string) (*tls.Config, error) {
 	tlsConf := &tls.Config{
-		GetCertificate: r.GetCertificate,
+		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) { return r.GetCertificate() },
 	}
 
 	if clientCAFile != "" {


### PR DESCRIPTION
I had misread the `tls.Config` documentation and assumed `GetCertificate` was used for both server and client certificates.
This was wrong, while client certificates can be provided in `Certificates`, if you want to use function, you have to set `GetClientCertificate`.

This PR fixes that.

In the future I intend to refactor this further and remove the fsnotify watcher and instead rely on a polling approach. This will allow us to remove a lot of code for the same result.