### PR TITLE
pprof: Generate runtime pprof file on non deamon process

### DIFF
--- a/fxpprof/pprof.go
+++ b/fxpprof/pprof.go
@@ -115,7 +115,7 @@ func NewPprofHttpServer(lc fx.Lifecycle, conf PprofConfig, logger *zap.Logger) (
 	return server, nil
 }
 
-func InitPprofProfiler(conf PprofConfig, server *http.Server) {
+func InitPprofProfiler(server *http.Server) {
 	if server == nil {
 		return
 	}


### PR DESCRIPTION
The idea is to generate a pprof  file on one-time execution program like replication, gc...etc

flag
```
-pprofgeneratefile "/etc/grpc......"
```