### PR TITLE
Disable log sampling

### DIFF
--- a/fxlogging/logging.go
+++ b/fxlogging/logging.go
@@ -55,7 +55,6 @@ func NewLogger(conf LoggingConfig, lc fx.Lifecycle) (*zap.Logger, error) {
 	switch conf.GetLogging().Mode {
 	case "production":
 		config = zap.NewProductionConfig()
-		config.Sampling = nil
 	case "preproduction":
 		config = zap.NewProductionConfig()
 		config.Sampling = nil


### PR DESCRIPTION
I've been tricked by zap dropping identical logs when they are emitted to often. 
https://github.com/uber-go/zap/blob/master/FAQ.md#why-are-some-of-my-logs-missing
[ch52128]