### PR TITLE
Fix error with very short lived grpc server

### DIFF
--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -136,7 +136,7 @@ func NewGrpcServer(p GrpcServerParams) (*grpc.Server, error) {
 			p.Logger.Info("Starting gRPC server", zap.Int("port", serverConf.Port))
 			go func() {
 				if err := grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {
-					// If err is grpc.ErrServerStopped, it mean that
+					// If err is grpc.ErrServerStopped, it means that
 					// the grpc module was stopped very quickly before
 					// this goroutine was scheduled
 					p.Logger.Fatal("Error while serving grpc", zap.Error(err))


### PR DESCRIPTION
In block storage tests I start and instantly stop fx app with a grpc server. 
This can result in the following error:
> FATAL	fxgrpc/grpc-server.go:139	Error while serving grpc	{"error": "grpc: the server has been stopped"}
github.com/exoscale/stelling/fxgrpc.NewGrpcServer.func1.1

This occurs because `OnStart` returns before the call to `Serve()`, so `GracefulStop` can be called before `Serve`, causing an error.  