### PR TITLE
Log the real port that was binded

### DIFF
--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -133,7 +133,7 @@ func NewGrpcServer(p GrpcServerParams) (*grpc.Server, error) {
 			if err != nil {
 				return err
 			}
-			p.Logger.Info("Starting gRPC server", zap.Int("port", serverConf.Port))
+			p.Logger.Info("Starting gRPC server", zap.Int("port", lis.Addr().(*net.TCPAddr).Port))
 			go func() {
 				if err := grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {
 					// If err is grpc.ErrServerStopped, it means that


### PR DESCRIPTION
If the port in the config is 0, we will bind on a random free port. Let's log this one