### PR TITLE
fix(logging): Made default grpc level mapping function public

### DIFF
--- a/fxlogging/logging.go
+++ b/fxlogging/logging.go
@@ -23,7 +23,7 @@ var Module = fx.Options(
 			NewGrpcServerInterceptors,
 			NewGrpcClientInterceptors,
 		),
-		fx.Supply(defaultCodeToLevel),
+		fx.Supply(DefaultCodeToLevel),
 	),
 )
 
@@ -125,8 +125,8 @@ func NewFxLogger(logger *zap.Logger) fxevent.Logger {
 	return &fxevent.ZapLogger{Logger: logger}
 }
 
-// defaultCodeToLevel maps the grpc response code to a logging level
-func defaultCodeToLevel(code codes.Code) zapcore.Level {
+// DefaultCodeToLevel maps the grpc response code to a logging level
+func DefaultCodeToLevel(code codes.Code) zapcore.Level {
 	switch code {
 	case codes.OK:
 		return zap.InfoLevel


### PR DESCRIPTION
When trying to integrate this in the NBDAgent, it turned out that having access to the default mapping function outside of this package is useful.

[sc-52719]