### PR TITLE
fix(http): Register http-server hooks in invoke functions

### DIFF
--- a/fxlogging/logging.go
+++ b/fxlogging/logging.go
@@ -74,13 +74,16 @@ func NewLogger(conf LoggingConfig, lc fx.Lifecycle) (*zap.Logger, error) {
 	}
 
 	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			// By logging here we render the decorated config
+			logger.Info("Using configuration", zap.Any("conf", conf))
+			return nil
+		},
 		OnStop: func(ctx context.Context) error {
 			_ = logger.Sync()
 			return nil
 		},
 	})
-
-	logger.Info("Using configuration", zap.Any("conf", conf))
 
 	return logger, nil
 }


### PR DESCRIPTION
We currently have a race condition between the shutdown of the grpc/http-server and our actual services, because the lifecycle hooks of the servers are registered in the constructor and the constructor can't have a dependency on the service (being "generic").

This change moves the registering of the lifecycle hooks to the eager invoke function.
This causes them to be registered near the end, specifically after the lifecycle hooks of the services, which should still be registered in the constructors.
We will therefore get non racy shutdown behaviour.

It does mean that the ordering of module definitions in users now becomes important: the fxhttp or fxgrpc module should probably be last in the system definition. Invoke functions are called in the order in which they are defined.

As for chosing when lifecycle should be registered in Invoke functions, I'm currently using this guideline:
If your module is a leaf in the dependency tree, it should be in the Invoke function, otherwise in the constructor. For these kind of modules we now typically have an empty invoke function with just a log line to force their creation.

Now that fx has named subgraphs, I refactored our http-server usage in terms of that.

There are 2 additional changes possible now, but I'm still debating their usefulness:
* We can embed the fxhttp config inside of the Metrics and Pprof modules now. I think this is more elegant, but would be a breaking config change on consumers.
* It would be nice to be able to expose metrics and pprof modules that do not embed their own http server: they would register their endpoints on the http server provided by the main system. I'm still thinking on how to name these, and whether these should use a different config struct, or whether it's ok to reuse the structs. I currently don't think it's worth to toggle this behaviour 'at runtime' via a config flag: a system will either want to use dedicated http servers for these modules or it won't. I think it's a system designer choice rather than a system user choice.