### PR TITLE
fix(dependencies): Do not invoke servers in their modules

### DIFF
--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -33,7 +33,6 @@ var ServerModule = fx.Module(
 		),
 		NewGrpcServer,
 	),
-	fx.Invoke(StartGrpcServer),
 )
 
 type GrpcServerConfig interface {

--- a/fxhttp/http.go
+++ b/fxhttp/http.go
@@ -20,32 +20,36 @@ var Module = fx.Module(
 		fx.Annotate(reloader.ProvideCertReloader, fx.ParamTags(``, `optional:"true"`, ``)),
 		fx.Annotate(NewHTTPServer, fx.ParamTags(``, ``, `optional:"true"`)),
 	),
-	fx.Invoke(StartHttpServer),
 )
 
 func NewNamedModule(name string) fx.Option {
 	nameTag := fmt.Sprintf("name:\"%s\"", name)
 	optNameTag := fmt.Sprintf("%s, optional:\"true\"", nameTag)
 	moduleName := fmt.Sprintf("%s-http-server", name)
-	return fx.Module(
-		moduleName,
-		fx.Provide(
-			fx.Annotate(
-				GetCertReloaderConfig,
-				fx.ParamTags(optNameTag),
-				fx.ResultTags(nameTag),
-			),
-			fx.Annotate(
-				reloader.ProvideCertReloader,
-				fx.ParamTags(``, optNameTag, ``),
-				fx.ResultTags(nameTag),
-			),
-			fx.Annotate(
-				NewHTTPServer,
-				fx.ParamTags(``, optNameTag, `optional:"true"`),
-				fx.ResultTags(nameTag),
+	return fx.Options(
+		fx.Module(
+
+			moduleName,
+			fx.Provide(
+				fx.Annotate(
+					GetCertReloaderConfig,
+					fx.ParamTags(optNameTag),
+					fx.ResultTags(nameTag),
+				),
+				fx.Annotate(
+					reloader.ProvideCertReloader,
+					fx.ParamTags(``, optNameTag, ``),
+					fx.ResultTags(nameTag),
+				),
+				fx.Annotate(
+					NewHTTPServer,
+					fx.ParamTags(``, optNameTag, `optional:"true"`),
+					fx.ResultTags(nameTag),
+				),
 			),
 		),
+		// We're not putting this in the module, so that the module which
+		// embeds this can chose when the http server should start
 		fx.Invoke(
 			fx.Annotate(
 				StartHttpServer,


### PR DESCRIPTION
It turns out that Invoke functions in modules run before Invoke functions in the parent. This means that the http and grpc servers will still start before their services are started.

With this in mind, I thought it was best if users explicitly call the Invoke functions in their apps: this gives them total control over the ordering and removes the significance of the order in which modules are embedded in the system.

This behaviour will have to be documented.

[sc-57631]