### PR TITLE
feat(grpc): Add ServiceRegistrar to grpc server module

### DIFF
--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -32,6 +32,7 @@ var ServerModule = fx.Module(
 			fx.ResultTags(`name:"grpc_server"`),
 		),
 		NewGrpcServer,
+		func(server *grpc.Server) grpc.ServiceRegistrar { return server },
 	),
 )
 


### PR DESCRIPTION
Adds a constructor that typecasts the grpc-server to a registrar.

This way consumer can embed `pb.RegisterMyServiceServer` directly in their system, without the need for a wrapping function to satisfy fx reflection.