### PR TITLE
grpctest: Adding support for interceptors

### DIFF
--- a/fxgrpc/grpctest/grpctest.go
+++ b/fxgrpc/grpctest/grpctest.go
@@ -20,7 +20,15 @@ var Module = fx.Module(
 	),
 )
 
-func NewGrpc(p fxgrpc.GrpcServerParams) (*grpc.Server, grpc.ClientConnInterface) {
+type GrpcServerParams struct {
+	fx.In
+
+	Lc                 fx.Lifecycle
+	UnaryInterceptors  []grpc.UnaryServerInterceptor  `group:"unary_server_interceptor"`
+	StreamInterceptors []grpc.StreamServerInterceptor `group:"stream_server_interceptor"`
+}
+
+func NewGrpc(p GrpcServerParams) (*grpc.Server, grpc.ClientConnInterface) {
 	lis := bufconn.Listen(1024 * 1024)
 
 	bufDialer := func(context.Context, string) (net.Conn, error) {


### PR DESCRIPTION
It's required to write tests for https://github.com/exoscale/sos/pull/774