### PR TITLE
fix(config): More robust flagName generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/TheZeroSlave/zapsentry v1.12.0
-	github.com/exoscale/multiconfig v0.0.0-20230112140713-34eb52e96465
+	github.com/exoscale/multiconfig v0.0.0-20230112165055-e91a7cafbafc
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/getsentry/sentry-go v0.17.0
 	github.com/go-logr/zapr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/exoscale/multiconfig v0.0.0-20230112131658-eec2d23c0875 h1:ASo6hXnFpt
 github.com/exoscale/multiconfig v0.0.0-20230112131658-eec2d23c0875/go.mod h1:roSLpjMwWNmyIgvZn6gcXZ8R/hlGVnSiw+YpoXH/Gyk=
 github.com/exoscale/multiconfig v0.0.0-20230112140713-34eb52e96465 h1:9G5cIH527l2wA+TV27hp65byFTMUNxpIJ/Vcx8rUHqM=
 github.com/exoscale/multiconfig v0.0.0-20230112140713-34eb52e96465/go.mod h1:thylIm+voytgvz6QMXgP6rZ8ZWKD3kkGFVpTHCCexyY=
+github.com/exoscale/multiconfig v0.0.0-20230112165055-e91a7cafbafc h1:UElM8YnZ8sgG0rhXEbpUrsxFLGziZTK4d9yZAgw/BA0=
+github.com/exoscale/multiconfig v0.0.0-20230112165055-e91a7cafbafc/go.mod h1:thylIm+voytgvz6QMXgP6rZ8ZWKD3kkGFVpTHCCexyY=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/cespare/xxhash/v2
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/exoscale/multiconfig v0.0.0-20230112140713-34eb52e96465
+# github.com/exoscale/multiconfig v0.0.0-20230112165055-e91a7cafbafc
 ## explicit; go 1.19
 github.com/exoscale/multiconfig
 # github.com/fatih/camelcase v1.0.0


### PR DESCRIPTION
Having to propagate patches through 2 libs is a bit cumbersome.
If I need to keep making changes multiconfig, I might just replicate its code in here to limit the amount of PRs I need to do.