### PR TITLE
fix(config): Ensure env loading matches generated flags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -75,7 +75,9 @@ func Load(s interface{}, args []string, opts ...Option) error {
 		// Load default configuration from struct tags
 		tagLoader: &multiconfig.TagLoader{},
 		// Load configuration from environment variables
-		envLoader: &multiconfig.EnvironmentLoader{},
+		envLoader: &multiconfig.EnvironmentLoader{
+			CamelCase: true,
+		},
 		// Load configuration from CLI flags
 		flagLoader: &multiconfig.FlagLoader{
 			Args:            newArgs[1:],

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,7 +89,7 @@ func TestConfigFromEnvironment(t *testing.T) {
 		MyString: "EnvironmentVariable",
 	}
 
-	t.Setenv("CONFIG_MYSTRING", "EnvironmentVariable")
+	t.Setenv("CONFIG_MY_STRING", "EnvironmentVariable")
 
 	config := Config{}
 	if assert.NoError(t, Load(&config, mockArgs)) {
@@ -124,8 +124,8 @@ loadflag: YAML`)
 	assert.NoError(t, err, "Failed to write to temporary file")
 	assert.NoError(t, confFile.Close(), "Failed to close temporary file")
 
-	t.Setenv("CONFIG_LOADENV", "Env")
-	t.Setenv("CONFIG_LOADFLAG", "Env")
+	t.Setenv("CONFIG_LOAD_ENV", "Env")
+	t.Setenv("CONFIG_LOAD_FLAG", "Env")
 
 	args := []string{
 		"conf",


### PR DESCRIPTION
The environment variable format produced by our help text did not match the format the config loader was looking for.

I adapted the loader to use the same format.

Alternatively, I can also update the generated help text if we think the current format is more consistent (it'll only put `_` between structnames atm)