### PR TITLE
feat(net): Allow specifying an IP for TCP servers to bind to

### DIFF
--- a/fxgrpc/grpc-client.go
+++ b/fxgrpc/grpc-client.go
@@ -110,7 +110,7 @@ type Client struct {
 	// RootCAFile is the  path to a pem encoded CA bundle used to validate server connections
 	RootCAFile string `validate:"omitempty,file"`
 	// Endpoint is IP or hostname or scheme for the target gRPC server
-	Endpoint string `validate:"required,omitempty"`
+	Endpoint string `validate:"required"`
 }
 
 func (c *Client) GrpcClientConfig() *Client {

--- a/fxhttp/http.go
+++ b/fxhttp/http.go
@@ -88,7 +88,11 @@ type ServerConfig interface {
 }
 
 type Server struct {
+	// Address is the address+port the gRPC server will bind to, as passed to net.Listen
+	// Takes precedence over Port
+	Address string
 	// Port is the port the http server will bind to
+	// Deprecated
 	Port int `default:"8080" validate:"port"`
 	// TLS indicates whether the http server exposes with TLS
 	TLS bool
@@ -130,8 +134,12 @@ func GetCertReloaderConfig(conf ServerConfig) *reloader.CertReloaderConfig {
 }
 
 func NewHTTPServer(lc fx.Lifecycle, conf ServerConfig, r *reloader.CertReloader) (*http.Server, error) {
+	addr := conf.HttpServerConfig().Address
+	if addr == "" {
+		addr = fmt.Sprintf(":%d", conf.HttpServerConfig().Port)
+	}
 	server := &http.Server{
-		Addr: fmt.Sprintf(":%d", conf.HttpServerConfig().Port),
+		Addr: addr,
 	}
 
 	if conf.HttpServerConfig().TLS {


### PR DESCRIPTION
We have usecases where the server should only be exposed on localhost.
This adds the necessary config to achieve that.

It deprecates the `Port` conf variable in favor of the `Addr` variable.
The GrpcClient already works like this, so we get consistent configuration.

When we remove `Port`, we will have to update the defaults in modules that embed `fxhttp.Server`.

[sc-67397]