### PR TITLE
feat(grpc): Install vtproto codec by default

### DIFF
--- a/fxgrpc/README.md
+++ b/fxgrpc/README.md
@@ -7,6 +7,9 @@ This package provides 2 modules:
 * A grpc server module
 * A grpc client module
 
+It will also install a custom codec that uses [vtprotobuf](https://github.com/planetscale/vtprotobuf)
+optimized (un)marshaling when possible.
+
 ## Server
 
 ### Components 

--- a/fxgrpc/codec.go
+++ b/fxgrpc/codec.go
@@ -1,0 +1,56 @@
+package fxgrpc
+
+import (
+	"fmt"
+
+	// use the original golang/protobuf package we can continue serializing
+	// messages from our dependencies that don't use vtproto
+	"github.com/golang/protobuf/proto" //nolint
+
+	"google.golang.org/grpc/encoding"
+	_ "google.golang.org/grpc/encoding/proto"
+)
+
+// Name is the name registered for the proto compressor.
+const Name = "proto"
+
+type vtprotoCodec struct{}
+
+type vtprotoMessage interface {
+	MarshalVT() ([]byte, error)
+	UnmarshalVT([]byte) error
+}
+
+func (vtprotoCodec) Marshal(v interface{}) ([]byte, error) {
+	vt, ok := v.(vtprotoMessage)
+	if ok {
+		return vt.MarshalVT()
+	}
+
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
+	}
+	return proto.Marshal(vv)
+}
+
+func (vtprotoCodec) Unmarshal(data []byte, v interface{}) error {
+	vt, ok := v.(vtprotoMessage)
+	if ok {
+		return vt.UnmarshalVT(data)
+	}
+
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
+	}
+	return proto.Unmarshal(data, vv)
+}
+
+func (vtprotoCodec) Name() string {
+	return Name
+}
+
+func init() {
+	encoding.RegisterCodec(vtprotoCodec{})
+}


### PR DESCRIPTION
The vtprotoc codec must be installed at init time.

We currently do this in all our gRPC servers, but often forget in programs that only have a client.
By adding the codec and its installation here, we will always use the optimized code if it is available.

Since the codec provides a fallback to the regular (un)marshaling code, this is safe.