### PR TITLE
feat(logging): Lower logging level of a succesfull grpc healthcheck

### DIFF
--- a/fxlogging/interceptor/logging_interceptor.go
+++ b/fxlogging/interceptor/logging_interceptor.go
@@ -80,7 +80,7 @@ type reporter struct {
 func (r *reporter) Log(ctx context.Context, payload any, handleErr error) {
 	duration := time.Since(r.startTime)
 	code := status.Code(handleErr)
-	level := r.conf.levelFunc(code)
+	level := r.conf.levelFunc(r.info, code)
 	traceid, _ := traceIdFromContext(ctx)
 
 	// TODO: refactor this using otel.semconv

--- a/fxlogging/interceptor/logging_interceptor_test.go
+++ b/fxlogging/interceptor/logging_interceptor_test.go
@@ -186,7 +186,7 @@ func TestLoggingServerInterceptor(t *testing.T) {
 		}
 		extraOpts := fx.Provide(
 			func() []Option {
-				codeToLevel := func(code codes.Code) zapcore.Level {
+				codeToLevel := func(_ *otelgrpc.InterceptorInfo, code codes.Code) zapcore.Level {
 					return zapcore.WarnLevel
 				}
 				return []Option{WithLevelFunc(codeToLevel)}


### PR DESCRIPTION
Lowers the logging level of a successful grpc healthcheck.

See https://github.com/grpc/grpc/blob/master/doc/health-checking.md for more information on the protocol.

This could be made smarter by inspecting (or printing) the payload of the response, but we don't really customize this at the moment, so I'm keeping it simple for now.

I'm also thinking of replacing this otel borrowed rpc info struct with something we own, to save on calls to MethodFromInterceptorInfo.

[sc-69862]