### PR TITLE
fix(grpc): Sort interceptors and remove nil objects

### DIFF
--- a/fxgrpc/grpc-client.go
+++ b/fxgrpc/grpc-client.go
@@ -243,15 +243,13 @@ func getDialOpts(conf *Client, logger *zap.Logger, ui []grpc.UnaryClientIntercep
 func NewGrpcClient(conf ClientConfig, logger *zap.Logger, ui []*UnaryClientInterceptor, si []*StreamClientInterceptor, dOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	clientConf := conf.GrpcClientConfig()
 
-	SortInterceptors(ui)
-	unaryIx := make([]grpc.UnaryClientInterceptor, len(ui))
-	for i := range ui {
-		unaryIx[i] = ui[i].Interceptor
+	unaryIx := make([]grpc.UnaryClientInterceptor, 0, len(ui))
+	for _, ix := range SortInterceptors(ui) {
+		unaryIx = append(unaryIx, ix.Interceptor)
 	}
-	SortInterceptors(si)
-	streamIx := make([]grpc.StreamClientInterceptor, len(si))
-	for i := range si {
-		streamIx[i] = si[i].Interceptor
+	streamIx := make([]grpc.StreamClientInterceptor, 0, len(si))
+	for _, ix := range SortInterceptors(si) {
+		streamIx = append(streamIx, ix.Interceptor)
 	}
 
 	opts, _, err := getDialOpts(clientConf, logger, unaryIx, streamIx)
@@ -268,15 +266,13 @@ func NewGrpcClient(conf ClientConfig, logger *zap.Logger, ui []*UnaryClientInter
 func ProvideGrpcClient(p GrpcClientParams) (grpc.ClientConnInterface, error) {
 	clientConf := p.Conf.GrpcClientConfig()
 
-	SortInterceptors(p.UnaryInterceptors)
-	unaryIx := make([]grpc.UnaryClientInterceptor, len(p.UnaryInterceptors))
-	for i := range p.UnaryInterceptors {
-		unaryIx[i] = p.UnaryInterceptors[i].Interceptor
+	unaryIx := make([]grpc.UnaryClientInterceptor, 0, len(p.UnaryInterceptors))
+	for _, ix := range SortInterceptors(p.UnaryInterceptors) {
+		unaryIx = append(unaryIx, ix.Interceptor)
 	}
-	SortInterceptors(p.StreamInterceptors)
-	streamIx := make([]grpc.StreamClientInterceptor, len(p.StreamInterceptors))
-	for i := range p.StreamInterceptors {
-		streamIx[i] = p.StreamInterceptors[i].Interceptor
+	streamIx := make([]grpc.StreamClientInterceptor, 0, len(p.StreamInterceptors))
+	for _, ix := range SortInterceptors(p.StreamInterceptors) {
+		streamIx = append(streamIx, ix.Interceptor)
 	}
 	opts, r, err := getDialOpts(clientConf, p.Logger, unaryIx, streamIx)
 	if err != nil {

--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -123,15 +123,13 @@ func NewGrpcServer(p GrpcServerParams) (*grpc.Server, error) {
 	}
 
 	// Handle server middleware
-	SortInterceptors(p.UnaryInterceptors)
 	unary := []grpc.UnaryServerInterceptor{}
-	for i := range p.UnaryInterceptors {
-		unary = append(unary, p.UnaryInterceptors[i].Interceptor)
+	for _, ix := range SortInterceptors(p.UnaryInterceptors) {
+		unary = append(unary, ix.Interceptor)
 	}
-	SortInterceptors(p.StreamInterceptors)
 	stream := []grpc.StreamServerInterceptor{}
-	for i := range p.StreamInterceptors {
-		stream = append(stream, p.StreamInterceptors[i].Interceptor)
+	for _, ix := range SortInterceptors(p.StreamInterceptors) {
+		stream = append(stream, ix.Interceptor)
 	}
 	opts = append(opts, grpc.ChainUnaryInterceptor(unary...), grpc.ChainStreamInterceptor(stream...))
 

--- a/fxgrpc/interceptors.go
+++ b/fxgrpc/interceptors.go
@@ -56,14 +56,28 @@ func (w WeightedInterceptors) Len() int           { return len(w) }
 func (w WeightedInterceptors) Swap(i, j int)      { w[i], w[j] = w[j], w[i] }
 func (w WeightedInterceptors) Less(i, j int) bool { return w[i].GetWeight() < w[j].GetWeight() }
 
-// SortInterceptors will order the slice of given interceptors by mutating it in place
+// SortInterceptors will order the slice of given interceptors and returns the ordered slice
 // Items will be sorted in ascending weight
+// Any nil items will be removed
 // It is some sugar around sort.Sort to help with the type system checks
 // The interceptor list should never be so large that the performance of this function matters
-func SortInterceptors[T WeightedInterceptor](list []T) {
+func SortInterceptors[T WeightedInterceptor](list []T) []T {
 	iList := make([]WeightedInterceptor, len(list))
+	// Copy to into a new slice to make the type checker happy
 	for i := range list {
 		iList[i] = list[i]
 	}
+	// Remove any nil elements, disregarding order
+	for i := 0; i < len(iList); i++ {
+		if iList[i] == nil {
+			iList[i] = iList[0]
+			iList = iList[1:]
+		}
+	}
 	sort.Sort(WeightedInterceptors(iList))
+	// Copy in original, because type checker
+	for i := range iList {
+		list[i] = iList[i].(T)
+	}
+	return list[:len(iList)]
 }

--- a/fxgrpc/interceptors_test.go
+++ b/fxgrpc/interceptors_test.go
@@ -1,0 +1,82 @@
+package fxgrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortInterceptors(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []WeightedInterceptor
+		expected []WeightedInterceptor
+	}{
+		{
+			name:     "Should work with emty input",
+			input:    []WeightedInterceptor{},
+			expected: []WeightedInterceptor{},
+		},
+		{
+			name: "Should sort by ascending weight",
+			input: []WeightedInterceptor{
+				&StreamServerInterceptor{Weight: 100},
+				&StreamServerInterceptor{Weight: 1},
+				&StreamServerInterceptor{Weight: 75},
+				&StreamServerInterceptor{Weight: 22},
+				&StreamServerInterceptor{Weight: 12},
+			},
+			expected: []WeightedInterceptor{
+				&StreamServerInterceptor{Weight: 1},
+				&StreamServerInterceptor{Weight: 12},
+				&StreamServerInterceptor{Weight: 22},
+				&StreamServerInterceptor{Weight: 75},
+				&StreamServerInterceptor{Weight: 100},
+			},
+		},
+		{
+			name: "Should not change list if it's already sorted",
+			input: []WeightedInterceptor{
+				&StreamServerInterceptor{Weight: 1},
+				&StreamServerInterceptor{Weight: 12},
+				&StreamServerInterceptor{Weight: 22},
+				&StreamServerInterceptor{Weight: 75},
+				&StreamServerInterceptor{Weight: 100},
+			},
+			expected: []WeightedInterceptor{
+				&StreamServerInterceptor{Weight: 1},
+				&StreamServerInterceptor{Weight: 12},
+				&StreamServerInterceptor{Weight: 22},
+				&StreamServerInterceptor{Weight: 75},
+				&StreamServerInterceptor{Weight: 100},
+			},
+		},
+		{
+			name: "Should remove nil slice elements",
+			input: []WeightedInterceptor{
+				nil,
+				&StreamServerInterceptor{Weight: 100},
+				&StreamServerInterceptor{Weight: 1},
+				&StreamServerInterceptor{Weight: 75},
+				nil,
+				&StreamServerInterceptor{Weight: 22},
+				&StreamServerInterceptor{Weight: 12},
+				nil,
+			},
+			expected: []WeightedInterceptor{
+				&StreamServerInterceptor{Weight: 1},
+				&StreamServerInterceptor{Weight: 12},
+				&StreamServerInterceptor{Weight: 22},
+				&StreamServerInterceptor{Weight: 75},
+				&StreamServerInterceptor{Weight: 100},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := SortInterceptors(tc.input)
+			require.EqualValues(t, tc.expected, output)
+		})
+	}
+}


### PR DESCRIPTION
The sorting of interceptors was bugged and we never used the sorted result.

Also makes the code a bit more lenient in case the client ends up providing a nil interceptor.