### PR TITLE
Fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.18
 
 require (
 	github.com/TheZeroSlave/zapsentry v1.12.0
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/exoscale/multiconfig v0.0.0-20230125174416-7beaf41f3d8e
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/getsentry/sentry-go v0.17.0
 	github.com/go-logr/zapr v1.2.3
 	github.com/go-playground/validator/v10 v10.11.1
+	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/prometheus/client_golang v1.14.0
@@ -32,7 +34,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
@@ -40,7 +41,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect


### PR DESCRIPTION
(Since the last PR?), stelling can't be imported anymore in other projects:

```
~/code/compute/agent master !2 ?1                                                                                                                                                                                                                      14:06:56
❯ go mod vendor                            
go: downloading libvirt.org/go/libvirt v1.9002.0
go: downloading libvirt.org/go/libvirtxml v1.9002.0
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc
go: downloading github.com/prometheus/procfs v0.10.1
go: downloading github.com/BurntSushi/toml v1.3.0
go: downloading google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc
go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc
github.com/exoscale/compute/agent/blockstorage imports
	github.com/exoscale/stelling/fxgrpc imports
	github.com/exoscale/stelling/fxhttp imports
	github.com/coreos/go-systemd/activation: missing go.sum entry for module providing package github.com/coreos/go-systemd/activation (imported by github.com/exoscale/stelling/fxhttp); to add:
	go get github.com/exoscale/stelling/fxhttp@v0.0.0-20230616110859-378f262b80a0
```

I ran `go mod tidy && go mod vendor` and it should fix it