### PR TITLE
http: revert to use defaults

### DIFF
--- a/fxhttp/http.go
+++ b/fxhttp/http.go
@@ -97,13 +97,13 @@ type ServerConfig interface {
 }
 
 type Server struct {
-	// Address is the address+port the gRPC server will bind to, as passed to net.Listen
-	// Takes precedence over Port
-	Address string `validate:"required_without=SocketName,excluded_with=SocketName"`
-	// A systemd socket name can also be supplied, but it is mutually exclusive with Address
+	// A systemd socket name. Takes precedence over Address
 	// In order to simplify, only systemd-activated socket with names are allowed, even if it is
 	// just one socket
-	SocketName string `validate:"required_without=Address,excluded_with=Address"`
+	SocketName string
+	// Address is the address+port the server will bind to, as passed to net.Listen
+	// Takes precedence over Port
+	Address string `default:"localhost:8080"`
 	// Port is the port the http server will bind to
 	// Deprecated
 	Port int `default:"8080" validate:"port"`
@@ -159,7 +159,6 @@ func NewListener(conf ServerConfig) (net.Listener, error) {
 		}
 		return net.Listen("tcp", addr)
 	}
-
 }
 
 func NewHTTPServer(lc fx.Lifecycle, conf ServerConfig, r *reloader.CertReloader) (*http.Server, error) {

--- a/fxhttp/http_example_test.go
+++ b/fxhttp/http_example_test.go
@@ -20,7 +20,7 @@ type Config struct {
 
 func Example() {
 	conf := &Config{}
-	args := []string{"http-test", "--server.address", "localhost:8080"}
+	args := []string{"http-test"}
 	if err := sconfig.Load(conf, args); err != nil {
 		panic(err)
 	}

--- a/fxmetrics/metrics.go
+++ b/fxmetrics/metrics.go
@@ -48,6 +48,7 @@ type Metrics struct {
 
 func (m *Metrics) ApplyDefaults() {
 	m.Server.Port = 9091
+	m.Server.Address = ":9091"
 }
 
 func (m *Metrics) MetricsConfig() *Metrics {

--- a/fxmetrics/metrics_example_test.go
+++ b/fxmetrics/metrics_example_test.go
@@ -21,7 +21,7 @@ type Config struct {
 
 func Example() {
 	conf := &Config{}
-	args := []string{"metrics-test", "--metrics.server.address", "localhost:9091"}
+	args := []string{"metrics-test"}
 	if err := sconfig.Load(conf, args); err != nil {
 		panic(err)
 	}

--- a/fxpprof/pprof.go
+++ b/fxpprof/pprof.go
@@ -60,6 +60,7 @@ type Pprof struct {
 
 func (p *Pprof) ApplyDefaults() {
 	p.Server.Port = 9092
+	p.Server.Address = ":9092"
 }
 
 func (p *Pprof) PprofConfig() *Pprof {

--- a/fxpprof/pprof_example_test.go
+++ b/fxpprof/pprof_example_test.go
@@ -75,7 +75,7 @@ func Example_job() {
 	conf := &Config{}
 	// By setting GenerateFiles, we instruct the module to profile the entire
 	// process runtime and output the profiles in the given directory
-	args := []string{"pprof-job", "--pprof.generate-files", tmp, "-pprof.server.address", "localhost:9092"}
+	args := []string{"pprof-job", "--pprof.generate-files", tmp}
 	if err := sconfig.Load(conf, args); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Allow using defaults again, we assume `SocketName` overrides `Address`