### PR TITLE
chore(http): Remove deprecated Port config variable

### DIFF
--- a/fxgrpc/README.md
+++ b/fxgrpc/README.md
@@ -31,7 +31,7 @@ The server can further be customized by providing [grpc.ServerOptions](https://p
 ### Configuration
 The module provides the following configuration options:
 
-* `Port`: The port on which the grpc server will bind
+* `Address`: The address + port on which the grpc server will bind
 * `TLS`: A boolean indicating that the server must expose using TLS
 * `CertFile`: Path to the pem encoded server TLS certificate
 * `KeyFile`: Path to the pem encoded private key of the server TLS certificate

--- a/fxhttp/README.md
+++ b/fxhttp/README.md
@@ -25,7 +25,7 @@ The module will also use `CertficateReloader` in case the configuration specifie
 
 ## Configuration
 The module provides the following configuration options:
-* `Port`: The port on which the http server will bind
+* `Address`: The address + port on which the http server will bind
 * `TLS`: A boolean indicating that the server must expose using TLS
 * `CertFile`: Path to the pem encoded server TLS certificate
 * `KeyFile`: Path to the pem encoded private key of the server TLS certificate

--- a/fxhttp/http.go
+++ b/fxhttp/http.go
@@ -102,11 +102,7 @@ type Server struct {
 	// just one socket
 	SocketName string
 	// Address is the address+port the server will bind to, as passed to net.Listen
-	// Takes precedence over Port
 	Address string `default:"localhost:8080"`
-	// Port is the port the http server will bind to
-	// Deprecated
-	Port int `default:"8080" validate:"port"`
 	// TLS indicates whether the http server exposes with TLS
 	TLS bool
 	// CertFile is the path to the pem encoded TLS certificate
@@ -126,7 +122,6 @@ func (s *Server) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		return nil
 	}
 
-	enc.AddInt("port", s.Port)
 	enc.AddBool("tls", s.TLS)
 
 	if s.TLS {
@@ -152,12 +147,7 @@ func NewListener(conf ServerConfig) (net.Listener, error) {
 	if socketName != "" {
 		return NamedSocketListener(socketName)
 	} else {
-		addr := conf.HttpServerConfig().Address
-
-		if addr == "" {
-			addr = fmt.Sprintf(":%d", conf.HttpServerConfig().Port)
-		}
-		return net.Listen("tcp", addr)
+		return net.Listen("tcp", conf.HttpServerConfig().Address)
 	}
 }
 

--- a/fxmetrics/metrics.go
+++ b/fxmetrics/metrics.go
@@ -47,7 +47,6 @@ type Metrics struct {
 }
 
 func (m *Metrics) ApplyDefaults() {
-	m.Server.Port = 9091
 	m.Server.Address = ":9091"
 }
 

--- a/fxpprof/pprof.go
+++ b/fxpprof/pprof.go
@@ -59,7 +59,6 @@ type Pprof struct {
 }
 
 func (p *Pprof) ApplyDefaults() {
-	p.Server.Port = 9092
 	p.Server.Address = ":9092"
 }
 


### PR DESCRIPTION
We broke usage of this by given `Address` a default value.
Let's just take the flight forward and remove it wholesale.