### PR TITLE
chore(sentry): Always emit a sentry client

### DIFF
--- a/fxsentry/sentry.go
+++ b/fxsentry/sentry.go
@@ -15,9 +15,6 @@ import (
 )
 
 func NewModule(conf SentryConfig) fx.Option {
-	if conf.SentryConfig().Dsn == "" {
-		return fx.Options()
-	}
 	return fx.Options(
 		fx.Supply(fx.Annotate(conf, fx.As(new(SentryConfig)))),
 		fx.Provide(ProvideSentryClient),
@@ -61,10 +58,6 @@ func (s *Sentry) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 func NewSentryClient(conf SentryConfig) (*sentry.Client, error) {
 	sentryConf := conf.SentryConfig()
-
-	if sentryConf.Dsn == "" {
-		return nil, nil
-	}
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/fxsentry/sentry_example_test.go
+++ b/fxsentry/sentry_example_test.go
@@ -51,18 +51,13 @@ func testDPanic(logger *zap.Logger) {
 }
 
 func testClient(client *sentry.Client) {
-	// Sentry does not provide a nop-client
-	// When no DSN is given in the config, the module does not create a client
-	// so we have to test for nil here
 	// This is the advanced usage: it is expected that most applications
 	// will only need the zap.DPanic integration which is fully transparent
-	if client != nil {
-		event := sentry.NewEvent()
-		event.Message = "My sentry"
-		event.Timestamp = time.Now()
-		event.Level = sentry.LevelInfo
-		client.CaptureEvent(event, nil, nil)
-	}
+	event := sentry.NewEvent()
+	event.Message = "My sentry"
+	event.Timestamp = time.Now()
+	event.Level = sentry.LevelInfo
+	client.CaptureEvent(event, nil, nil)
 }
 
 func shutdown(sd fx.Shutdowner) {


### PR DESCRIPTION
After reading the source, it turns out that the sentry client will turn itself into a noop client if the Dsn is not set. So there is no reason for us to also implement this behaviour.

[sc-72284]