### PR TITLE
Log at Warn level in case of AlreadyExists

### DIFF
--- a/fxlogging/interceptor/config.go
+++ b/fxlogging/interceptor/config.go
@@ -96,7 +96,7 @@ func DefaultServerCodeToLevel(info *otelgrpc.InterceptorInfo, code codes.Code) z
 	case codes.NotFound:
 		return zap.InfoLevel
 	case codes.AlreadyExists:
-		return zap.DebugLevel
+		return zap.WarnLevel
 	case codes.PermissionDenied:
 		return zap.WarnLevel
 	case codes.Unauthenticated:


### PR DESCRIPTION
We were confused as why a replication store-blob that was recreating it's indexes wasn't logging Puts 

We can debate whether it should log, but this default doesn't belong in stelling. This status code need to be logged for the operator, compute-agent, nbdagent etc....