### PR TITLE
fix(grpc): Ensure the grpc listener is tagged correctly

### DIFF
--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -194,7 +194,6 @@ type GrpcServerStartParams struct {
 	Lis    net.Listener `name:"grpc_server"`
 }
 
-// func StartGrpcServer(lc fx.Lifecycle, logger *zap.Logger, server *grpc.Server, conf Config, lis net.Listener) {
 func StartGrpcServer(p GrpcServerStartParams) {
 	lc := p.Lc
 	logger := p.Logger


### PR DESCRIPTION
- Use a struct as params for `fxgrpc.StartGrpcServer` to tag the correct grpc `net.Listener` so consumers don't need to tag it
- Drop unused conf from the params