### PR TITLE
fxmetrics: push_metrics: Add support for extra labels

### DIFF
--- a/fxmetrics/push_metrics.go
+++ b/fxmetrics/push_metrics.go
@@ -90,6 +90,8 @@ type PushMetrics struct {
 	// PushInterval is the frequency with which metrics are pushed
 	// If the PushInterval is set to 0, metrics will only be pushed when the system stops
 	PushInterval time.Duration `default:"15s"`
+	// ExtraLabels will add each key as a label with the corresponding value in all produced metrics
+	ExtraLabels map[string]string
 }
 
 func (m *PushMetrics) PushMetricsConfig() *PushMetrics {
@@ -172,6 +174,10 @@ func ProvideMetricsPusher(lc fx.Lifecycle, conf PushMetricsConfig, reloader *rel
 
 	if pConf.GroupingLabelKey != "" {
 		pusher = pusher.Grouping(pConf.GroupingLabelKey, pConf.GroupingLabelValue)
+	}
+
+	for name, value := range pConf.ExtraLabels {
+		pusher = pusher.Grouping(name, value)
 	}
 
 	if pConf.PushInterval == 0 {


### PR DESCRIPTION
[sc-77512]

Add configurable labels that can be added to all of the metrics we send to push-gateway.


This will mostly be used to push the `tenant: short-lived`, but getting something generic is always nicer !

---

![image](https://github.com/exoscale/stelling/assets/24977217/7011603d-d75d-402e-a09c-360a9aa9712a)

Tested in prod, the labels are correctly added to all of the produced metrics !