### PR TITLE
fxmetrics: push_metrics: Override instead of adding

### DIFF
--- a/fxmetrics/push_metrics.go
+++ b/fxmetrics/push_metrics.go
@@ -184,7 +184,7 @@ func ProvideMetricsPusher(lc fx.Lifecycle, conf PushMetricsConfig, reloader *rel
 		lc.Append(fx.Hook{
 			OnStop: func(ctx context.Context) error {
 				logger.Debug("Pushing final metrics")
-				return pusher.Add()
+				return pusher.Push()
 			},
 		})
 	} else {


### PR DESCRIPTION
Cf the pushgateway docs:
- POST requests will only add new metrics
- PUT requests will override all of the metrics with the same grouping keys => This is what we want for the decom at least (ie: we want to **remove** the `blobd_partition_pending_decom`)