### PR TITLE
chore(grpc): Remove RecvBufferPool option from config

### DIFF
--- a/fxgrpc/grpc-client.go
+++ b/fxgrpc/grpc-client.go
@@ -111,8 +111,6 @@ type Client struct {
 	RootCAFile string `validate:"omitempty,file"`
 	// Endpoint is IP or hostname or scheme for the target gRPC server
 	Endpoint string `validate:"required"`
-	// EnableRecvBufferPool enables the use of grpc buffer pooling in the recv loop
-	EnableRecvBufferPool bool
 }
 
 func (c *Client) GrpcClientConfig() *Client {
@@ -229,10 +227,6 @@ func getDialOpts(conf *Client, logger *zap.Logger, ui []grpc.UnaryClientIntercep
 		grpc.WithChainUnaryInterceptor(unary...),
 		grpc.WithChainStreamInterceptor(stream...),
 	)
-
-	if conf.EnableRecvBufferPool {
-		opts = append(opts, grpc.WithRecvBufferPool(grpc.NewSharedBufferPool()))
-	}
 
 	// TODO: move this side effect out into the calling functions?
 	grpclog.SetLoggerV2(zapgrpc.NewLogger(logger))

--- a/fxgrpc/grpc-server.go
+++ b/fxgrpc/grpc-server.go
@@ -38,11 +38,6 @@ type Server struct {
 	KeyFile string `validate:"required_if=TLS true,omitempty,file"`
 	// ClientCAFile is the path to a pem encoded CA cert bundle used to validate clients
 	ClientCAFile string `validate:"excluded_without=TLS,omitempty,file"`
-
-	// -imported
-
-	// EnableRecvBufferPool enables the use of grpc buffer pooling in the recv loop
-	EnableRecvBufferPool bool
 }
 
 func (s *Server) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -59,8 +54,6 @@ func (s *Server) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		enc.AddString("key-file", s.KeyFile)
 		enc.AddString("client-ca-file", s.ClientCAFile)
 	}
-
-	enc.AddBool("enable-recv-buffer-pool", s.EnableRecvBufferPool)
 
 	return nil
 }
@@ -173,10 +166,6 @@ func NewGrpcServer(p GrpcServerParams) (*grpc.Server, error) {
 
 	// Add the externally supplied options last: this allows the user to override any options we may have set already
 	opts = append(opts, p.ServerOpts...)
-
-	if serverConf.EnableRecvBufferPool {
-		opts = append(opts, grpc.RecvBufferPool(grpc.NewSharedBufferPool()))
-	}
 
 	// Set our logger as the logger used by the gRPC framework
 	grpclog.SetLoggerV2(zapgrpc.NewLogger(p.Logger))


### PR DESCRIPTION
This option is application specific: its value does not need to be runtime configuration.
Applications can pass in the `ServerOption` or `DialOption` via the fx system directly.

[sc-80259]