### PR TITLE
feat(ci): Enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: github.com/getsentry/sentry-go
+  groups:
+    all:
+      patterns:
+        - "*"
+- package-ecosystem: "github-actions"
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    all:
+      patterns:
+        - "*"


### PR DESCRIPTION
Based on the setup we have in SOS.

We can remove the sentry exclusion once we've moved over to the SaaS offering.