### PR TITLE
feat(logging): Make logging options for fx configurable

### DIFF
--- a/fxlogging/README.md
+++ b/fxlogging/README.md
@@ -25,6 +25,14 @@ with the name `logging_server_interceptor_options` and `logging_client_intercept
 This allows customization of the grpc code to log level mapping and passing in a custom decider for when
 requests or their payloads should be logged.
 
+All logs emitted by the fx system itself are also logged via the zap Logger. By default all events are logged
+at Debug level, errors are logged at Error level.
+These levels can be configured by injecting an `fxlogger.Option` using the "fxlogger_opts" value group into the system.
+
+```go
+fx.Supply(fx.Annotate(fxlogger.WithLogLevel(zapcore.InfoLevel), fx.ResultTags(`group:"fxlogger_opts"`)))
+```
+
 ## Configuration file
 At the moment the configuration for the logger only has a single option: `mode`:
 

--- a/fxlogging/fxlogger/logger.go
+++ b/fxlogging/fxlogger/logger.go
@@ -1,0 +1,42 @@
+package fxlogger
+
+import (
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type FxLoggerParams struct {
+	fx.In
+	Logger *zap.Logger
+	Opts   []Option `group:"fxlogger_opts"`
+}
+
+// NewFxLogger emits an fxevent.Logger that uses the passed in zap logger
+// The fxevent.Logger is used to write out the log messages produces by the fx framework
+func NewFxLogger(p FxLoggerParams) fxevent.Logger {
+	result := &fxevent.ZapLogger{Logger: p.Logger}
+	result.UseLogLevel(zapcore.DebugLevel)
+	for _, opt := range p.Opts {
+		opt(result)
+	}
+	return result
+}
+
+// Option are constructor parameters that configure the fxevent.Logger
+type Option func(l *fxevent.ZapLogger)
+
+// WithLogLevel sets the level at which fx will log the events that happen during system start and stop
+func WithLogLevel(lvl zapcore.Level) Option {
+	return func(l *fxevent.ZapLogger) {
+		l.UseLogLevel(lvl)
+	}
+}
+
+// WithErrorLevel sets the level at which fx will log any error events that happen during system start and stop
+func WithErrorLevel(lvl zapcore.Level) Option {
+	return func(l *fxevent.ZapLogger) {
+		l.UseErrorLevel(lvl)
+	}
+}

--- a/fxlogging/logging.go
+++ b/fxlogging/logging.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/exoscale/stelling/fxgrpc"
+	"github.com/exoscale/stelling/fxlogging/fxlogger"
 	"github.com/exoscale/stelling/fxlogging/interceptor"
 	"go.uber.org/fx"
-	"go.uber.org/fx/fxevent"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -19,7 +19,7 @@ import (
 // * An adapter to log fx system events
 func NewModule(conf LoggingConfig) fx.Option {
 	return fx.Options(
-		fx.WithLogger(NewFxLogger),
+		fx.WithLogger(fxlogger.NewFxLogger),
 		fx.Module(
 			"logging",
 			fx.Provide(
@@ -147,12 +147,4 @@ func NewGrpcInjectPeerInterceptors() (*fxgrpc.UnaryClientInterceptor, *fxgrpc.St
 	unaryIx := &fxgrpc.UnaryClientInterceptor{Weight: weight, Interceptor: interceptor.NewInjectPeerUnaryClientInterceptor()}
 	streamIx := &fxgrpc.StreamClientInterceptor{Weight: weight, Interceptor: interceptor.NewInjectPeerStreamClientInterceptor()}
 	return unaryIx, streamIx
-}
-
-// NewFxLogger emits an fxevent.Logger that uses the passed in zap logger
-// The fxevent.Logger is used to write out the log messages produces by the fx framework
-func NewFxLogger(logger *zap.Logger) fxevent.Logger {
-	result := &fxevent.ZapLogger{Logger: logger}
-	result.UseLogLevel(zapcore.DebugLevel)
-	return result
 }


### PR DESCRIPTION
This change allows us to change the levels at which fx logs events.

It needed some boilerplate because the configuration they themselves provide is not super fx friendly.
I went for the `Option` pattern we have already successfully used for gRPC options.

We could also use varargs on the `NewFxLogger` constructor and then annotate in the module, but I don't think we'll ever call this function outside of an fx context.

This was tested in blobd locally and confirmed to change the logging level of fx events.

[sc-84623]