### PR TITLE
Collect all go runtime metrics

### DIFF
--- a/fxmetrics/metrics.go
+++ b/fxmetrics/metrics.go
@@ -3,7 +3,6 @@ package fxmetrics
 
 import (
 	"net/http"
-	"regexp"
 
 	"github.com/exoscale/stelling/fxgrpc"
 	"github.com/exoscale/stelling/fxhttp"
@@ -158,7 +157,7 @@ func NewPrometheusRegistry(conf MetricsConfig) (*prometheus.Registry, error) {
 	err := reg.Register(
 		collectors.NewGoCollector(
 			collectors.WithGoCollectorRuntimeMetrics(
-				collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")},
+				collectors.MetricsAll,
 			),
 		),
 	)


### PR DESCRIPTION
By default prometheus' `NewGoCollector` only reports metrics that originate from the [runtime.ReadMemStats](https://pkg.go.dev/runtime#ReadMemStats) & [runtime/debug.ReadGCStats](https://pkg.go.dev/runtime/debug#ReadGCStats) functions. 

However the modern approach to introspect the go runtime is now the unified [runtime/metrics](https://pkg.go.dev/runtime/metrics@master) package. It exposes all previous metrics plus a handful of new ones.  I wanted to look at those metrics to understand better how the nbdagent performs. 

This change enables the reporting of the metrics coming from the unified package. 
It also ensures that we'll always report all the metrics exposed by the runtime. 

The downside of this change is that the collector now exposes ~100 new metrics (148 compared to 34 before).
It would be possible to only select a subset of them but I'm not sure it's really interesting. 

With this change we'll expose both the metrics coming for the "previous" and "new" mechanism so ~30 metrics are going to be duplicated. In theory we wouldn't loose any data by only gathering the metrics from the "new" package, but it'd break dashboard as the metric names change (eg https://grafana.internal.exoscale.ch/d/c8235001-f013-42c1-83ee-33983f371e22/go-processes-instance)