### PR TITLE
feat(metrics): Make it possible to set version info with the linker

### DIFF
--- a/fxmetrics/version_collector.go
+++ b/fxmetrics/version_collector.go
@@ -6,14 +6,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// NewVersionCollector returns a collector collecting a single metric
-// "go_version_info" with the constant value of 1 and 2 labels "revision"
-// and "revision_timestamp". Their labels will contain the values of
-// "vcs.revision" and "vcs.time" from the BuildInfo.Settings map or "unknown"
-// if the vcs information is not available.
+var revision, revisionTimestamp = "unknown", "unknown"
+
+// NewVersionCollector returns a collector collecting a single metric "go_version_info" with the
+// constant value of 1 and 2 labels "revision" and "revision_timestamp".
+// Their values can be set at link time.
+// `go build -ldflags="-X 'github.com/exoscale/stelling/fxmetrics.revision=v1.0.0'"`
+// `go build -ldflags="-X 'github.com/exoscale/stelling/fxmetrics.revisionTimestamp=2024-06-18T14:28:57Z'"`
+// If not set at link time, the labels will contain the values of "vcs.revision" and "vcs.time" from
+// the BuildInfo.Settings map.
+// If neither way returns an output, the value will be set to "unknown".
 func NewVersionCollector() prometheus.GaugeFunc {
-	revision, revisionTimestamp := "unknown", "unknown"
-	if info, ok := debug.ReadBuildInfo(); ok {
+	if info, ok := debug.ReadBuildInfo(); ok && revision == "unknown" {
 		for _, item := range info.Settings {
 			switch item.Key {
 			case "vcs.revision":


### PR DESCRIPTION
In order to set a value of a variable at link time, it must be at the package level.