### PR TITLE
linter: remove double-format calls

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -132,7 +132,7 @@ func Load(s interface{}, args []string, opts ...Option) error {
 			} else {
 				errorString += fmt.Sprintf("'%s=%v'", e.ActualTag(), e.Param())
 			}
-			return fmt.Errorf(errorString)
+			return errors.New(errorString)
 		}
 	}
 


### PR DESCRIPTION
The CI on master was complaining with the following issue:


```
  Running [/home/runner/golangci-lint-1.60.1-linux-amd64/golangci-lint run  --timeout 2m] in [/home/runner/work/stelling/stelling] ...
  Error: config/config.go:135:22: printf: non-constant format string in call to fmt.Errorf (govet)
  			return fmt.Errorf(errorString)
  			                  ^
  
  Error: issues found
  Ran golangci-lint in 91986ms
```