### PR TITLE
fxlogging: Add interceptor for http requests

### DIFF
--- a/fxlogging/interceptor/http.go
+++ b/fxlogging/interceptor/http.go
@@ -2,6 +2,7 @@ package interceptor
 
 import (
 	"net/http"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -26,6 +27,8 @@ func (w *WrapResponseWriter) WriteHeader(statusCode int) {
 
 func NewRequestLogger(logger *zap.Logger, wrapped http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
 		ww := NewWrapResponseWriter(w)
 
 		ctx := r.Context()
@@ -58,6 +61,7 @@ func NewRequestLogger(logger *zap.Logger, wrapped http.Handler) http.Handler {
 		l.Info(
 			"Handled request",
 			zap.Int("http.status", ww.StatusCode),
+			zap.Duration("http.duration", time.Since(start)),
 		)
 	})
 }


### PR DESCRIPTION
Adds a correlation id in the context & in the response headers, shows the result of all http requests, and forwards a context which includes the calling context to the wrapped handlers

# example interactions

```
2024-08-22T14:27:44.694+0200    INFO    http/interceptor.go:59  Handled request {"http.method": "GET", "http.uri": "/api/hosts", "otlp.trace_id": "local-01J5X0X85PK8EQQBKD13YXZWGC", "X-Forwarded-User": "albin", "status": 200}

fumesover@fixme-nixos ~> restish dev-blobd-orchestrator -H 'X-Forwarded-User: albin' list-hosts
HTTP/1.1 200 OK
Content-Length: 315
Content-Type: application/json
Date: Thu, 22 Aug 2024 12:27:44 GMT
X-Trace-Id: local-01J5X0X85PK8EQQBKD13YXZWGC

[...]
```

```
2024-08-22T14:27:48.278+0200    INFO    http/interceptor.go:59  Handled request {"http.method": "GET", "http.uri": "/api/hosts", "otlp.trace_id": "80e1afed08e019fc1110464cfa66635c", "X-Forwarded-User": "albin", "status": 200}

fumesover@fixme-nixos ~> restish dev-blobd-orchestrator -H 'X-Forwarded-User: albin' -H 'traceparent: 00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01' list-hosts
HTTP/1.1 200 OK
Content-Length: 315
Content-Type: application/json
Date: Thu, 22 Aug 2024 12:27:48 GMT
X-Trace-Id: 80e1afed08e019fc1110464cfa66635c

[...]
```

```
2024-08-22T14:29:13.312+0200    INFO    http/interceptor.go:59  Handled request {"http.method": "GET", "http.uri": "/api/orchestrator/pending-task/6", "otlp.trace_id": "80e1afed08e019fc1110464cfa66635c", "X-Forwarded-User": "albin", "status": 200}

fumesover@fixme-nixos ~> restish dev-blobd-orchestrator -H 'X-Forwarded-User: albin' -H 'traceparent: 00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01' get-pending-task 6
HTTP/1.1 200 OK
Content-Length: 41
Content-Type: application/json
Date: Thu, 22 Aug 2024 12:29:13 GMT
X-Trace-Id: 80e1afed08e019fc1110464cfa66635c

{
  Args: null
  Kind: "OK"
  Reasons: null
}
```

# example usage (in blobd-orchestrator, with otel tracing included)

```go
func RegisterRoutes(logger *zap.Logger, orch *Orchestrator, server *http.Server) {
	[...]

	propagators := propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})

	server.Handler = otelhttp.NewHandler(
		fxlogginghttp.NewRequestLogger(logger, mux),
		"server",
		otelhttp.WithPropagators(propagators),
		otelhttp.WithTracerProvider(tracerProvider),
	)
}
```