### PR TITLE
grpc: Use codecV2 & pool memory to hold serialized protos

### DIFF
--- a/fxgrpc/codec.go
+++ b/fxgrpc/codec.go
@@ -1,67 +1,68 @@
 package fxgrpc
 
 import (
-	"fmt"
 
 	// use the v2 proto package we can continue serializing
 	// messages from our dependencies that don't use vtproto
 	"google.golang.org/grpc/encoding"
+	// Guarantee that the built-in proto is called registered before this one
+	// so that it can be replaced.
 	_ "google.golang.org/grpc/encoding/proto"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/protoadapt"
+	"google.golang.org/grpc/mem"
 )
 
 // Name is the name registered for the proto compressor.
 const Name = "proto"
 
-type vtprotoCodec struct{}
-
 type vtprotoMessage interface {
-	MarshalVT() ([]byte, error)
+	MarshalToSizedBufferVT(data []byte) (int, error)
 	UnmarshalVT([]byte) error
+	SizeVT() int
 }
 
-func (vtprotoCodec) Marshal(v interface{}) ([]byte, error) {
-	vt, ok := v.(vtprotoMessage)
-	if ok {
-		return vt.MarshalVT()
-	}
-
-	vv := messageV2Of(v)
-	if vv == nil {
-		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
-	}
-	return proto.Marshal(vv)
+type codec struct {
+	fallback encoding.CodecV2
 }
 
-func (vtprotoCodec) Unmarshal(data []byte, v interface{}) error {
-	vt, ok := v.(vtprotoMessage)
-	if ok {
-		return vt.UnmarshalVT(data)
+func (codec) Name() string { return Name }
+
+// For the moment there's no way for consumer of stelling to change the memory pool used to hold serialized messages
+// But I'm not sure there's really a need for that
+var defaultBufferPool = mem.DefaultBufferPool()
+
+func (c *codec) Marshal(v any) (mem.BufferSlice, error) {
+	if m, ok := v.(vtprotoMessage); ok {
+		size := m.SizeVT()
+		if mem.IsBelowBufferPoolingThreshold(size) {
+			buf := make([]byte, size)
+			if _, err := m.MarshalToSizedBufferVT(buf[:size]); err != nil {
+				return nil, err
+			}
+			return mem.BufferSlice{mem.SliceBuffer(buf)}, nil
+		}
+		buf := defaultBufferPool.Get(size)
+		if _, err := m.MarshalToSizedBufferVT((*buf)[:size]); err != nil {
+			defaultBufferPool.Put(buf)
+			return nil, err
+		}
+		return mem.BufferSlice{mem.NewBuffer(buf, defaultBufferPool)}, nil
 	}
 
-	vv := messageV2Of(v)
-	if vv == nil {
-		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
-	}
-	return proto.Unmarshal(data, vv)
+	return c.fallback.Marshal(v)
 }
 
-func messageV2Of(v any) proto.Message {
-	switch v := v.(type) {
-	case protoadapt.MessageV1:
-		return protoadapt.MessageV2Of(v)
-	case protoadapt.MessageV2:
-		return v
+func (c *codec) Unmarshal(data mem.BufferSlice, v any) error {
+	if m, ok := v.(vtprotoMessage); ok {
+		buf := data.MaterializeToBuffer(defaultBufferPool)
+		defer buf.Free()
+		return m.UnmarshalVT(buf.ReadOnlyData())
 	}
 
-	return nil
-}
-
-func (vtprotoCodec) Name() string {
-	return Name
+	return c.fallback.Unmarshal(data, v)
 }
 
 func init() {
-	encoding.RegisterCodec(vtprotoCodec{})
+	encoding.RegisterCodecV2(&codec{
+		fallback: encoding.GetCodecV2("proto"),
+	})
 }


### PR DESCRIPTION
[ch104583]

Basically a copy-paste of https://github.com/vitessio/vitess/pull/16790