### PR TITLE
push metrics: dont use excluded_if

### DIFF
--- a/fxmetrics/push_metrics.go
+++ b/fxmetrics/push_metrics.go
@@ -92,7 +92,7 @@ type PushMetrics struct {
 	// The value for this instance of the GroupingLabel (see GroupingLabelKey)
 	GroupingLabelValue string `validate:"required_with=GroupingLabelKey"`
 
-	GroupingLabelKeys []string `validate:"excluded_if=GroupingLabelKey"`
+	GroupingLabelKeys []string `validate:"excluded_with=GroupingLabelKey"`
 	// The value for this instance of the GroupingLabel (see GroupingLabelKey)
 	GroupingLabelValues []string `validate:"required_with=GroupingLabelKeys"`
 


### PR DESCRIPTION
I misunderstood the `excluded_if` syntax, the use case is `excluded_if Field Value`; the correct validation is `excluded_with`:

```
    "pushmetrics": {
        "pushinterval": "0",
        "jobname": "exoscale-canary",
        "groupinglabelkeys": ["zone","repo"],
        "groupinglabelvalues": ["local-test2", "sos"],

        "groupinglabelkey": "zone",
        "groupinglabelvalue": "local-test2",
        "endpoint": "localhost:9091"
    },
```

```
$ go run main.go canary.go -f config.local.json
2025/01/21 14:37:43 Starting SOS canary
2025/01/21 14:37:43 Configuration error: 'CanaryConfig.PushMetrics.GroupingLabelKeys' = '[zone repo]' does not validate 'excluded_with=GroupingLabelKey'
exit status 1
```