### PR TITLE
feat(config): Adds support for various map types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/exoscale/stelling
 
 go 1.22
+
 toolchain go1.22.9
 
 require (
 	github.com/TheZeroSlave/zapsentry v1.23.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
-	github.com/exoscale/multiconfig v0.0.0-20230329142724-71ec8bdb4f80
+	github.com/exoscale/multiconfig v0.0.0-20250121154433-cb30610932f6
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-playground/validator/v10 v10.22.1

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/exoscale/multiconfig v0.0.0-20230329142724-71ec8bdb4f80 h1:yRYrK13jXTkBb+kB/kZXG9WasPoqKIEQu4I9APCDuuU=
-github.com/exoscale/multiconfig v0.0.0-20230329142724-71ec8bdb4f80/go.mod h1:thylIm+voytgvz6QMXgP6rZ8ZWKD3kkGFVpTHCCexyY=
+github.com/exoscale/multiconfig v0.0.0-20250121154433-cb30610932f6 h1:/EZ01ydSkr53UjIg2fCWeUvNYka5UHlqC/QzTk/acvc=
+github.com/exoscale/multiconfig v0.0.0-20250121154433-cb30610932f6/go.mod h1:n0skIbbd2HwtBcVYK+cbUPi/9KDvDGco5k4VZI4aLIQ=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=

--- a/vendor/github.com/exoscale/multiconfig/multiconfig.go
+++ b/vendor/github.com/exoscale/multiconfig/multiconfig.go
@@ -142,120 +142,405 @@ func fieldSet(field *structs.Field, v string) error {
 	case reflect.Bool:
 		val, err := strconv.ParseBool(v)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as bool: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(val); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Int:
 		i, err := strconv.Atoi(v)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as int: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(i); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.String:
 		if err := field.Set(v); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Slice:
 		switch t := field.Value().(type) {
 		case []string:
 			if err := field.Set(strings.Split(v, ",")); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		case []int:
 			var list []int
 			for _, in := range strings.Split(v, ",") {
-				i, err := strconv.Atoi(in)
+				i, err := strconv.ParseInt(in, 10, strconv.IntSize)
 				if err != nil {
-					return err
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int: %w", in, field.Name(), err)
 				}
 
-				list = append(list, i)
+				list = append(list, int(i))
 			}
 
 			if err := field.Set(list); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int64:
+			var list []int64
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int64: %w", in, field.Name(), err)
+				}
+				list = append(list, i)
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int32:
+			var list []int32
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int32: %w", in, field.Name(), err)
+				}
+				list = append(list, int32(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int16:
+			var list []int16
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int16: %w", in, field.Name(), err)
+				}
+				list = append(list, int16(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []int8:
+			var list []int8
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseInt(in, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int8: %w", in, field.Name(), err)
+				}
+				list = append(list, int8(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint:
+			var list []uint
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint: %w", in, field.Name(), err)
+				}
+				list = append(list, uint(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint64:
+			var list []uint64
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint64: %w", in, field.Name(), err)
+				}
+				list = append(list, i)
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint32:
+			var list []uint32
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint32: %w", in, field.Name(), err)
+				}
+				list = append(list, uint32(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint16:
+			var list []uint16
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint16: %w", in, field.Name(), err)
+				}
+				list = append(list, uint16(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case []uint8:
+			var list []uint8
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseUint(in, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint8: %w", in, field.Name(), err)
+				}
+				list = append(list, uint8(i))
+			}
+			if err := field.Set(list); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		default:
-			return fmt.Errorf("multiconfig: field '%s' of type slice is unsupported: %s (%T)",
+			return fmt.Errorf("field '%s' of type slice is unsupported: %s (%T)",
 				field.Name(), field.Kind(), t)
+		}
+	case reflect.Map:
+		switch field.Value().(type) {
+		case map[string]string:
+			output := map[string]string{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				output[key] = val
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int:
+			output := map[string]int{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int: %w", val, field.Name(), err)
+				}
+				output[key] = int(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int64:
+			output := map[string]int64{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int64: %w", val, field.Name(), err)
+				}
+				output[key] = i
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int32:
+			output := map[string]int32{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int32: %w", val, field.Name(), err)
+				}
+				output[key] = int32(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int16:
+			output := map[string]int16{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int16: %w", val, field.Name(), err)
+				}
+				output[key] = int16(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]int8:
+			output := map[string]int8{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseInt(val, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as int8: %w", val, field.Name(), err)
+				}
+				output[key] = int8(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint:
+			output := map[string]uint{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, strconv.IntSize)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint: %w", val, field.Name(), err)
+				}
+				output[key] = uint(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint64:
+			output := map[string]uint64{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 64)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint64: %w", val, field.Name(), err)
+				}
+				output[key] = i
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint32:
+			output := map[string]uint32{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 32)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint32: %w", val, field.Name(), err)
+				}
+				output[key] = uint32(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint16:
+			output := map[string]uint16{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 16)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint16: %w", val, field.Name(), err)
+				}
+				output[key] = uint16(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		case map[string]uint8:
+			output := map[string]uint8{}
+			for _, item := range strings.Split(v, ",") {
+				key, val, ok := strings.Cut(item, "=")
+				if !ok {
+					return fmt.Errorf("value '%s' of field '%s' is not a valid key/value pair ('=' missing)", item, field.Name())
+				}
+				i, err := strconv.ParseUint(val, 10, 8)
+				if err != nil {
+					return fmt.Errorf("cannot parse value '%s' of field '%s' as uint8: %w", val, field.Name(), err)
+				}
+				output[key] = uint8(i)
+			}
+			if err := field.Set(output); err != nil {
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
+			}
+		default:
+			return fmt.Errorf("field '%s' of type map is unsupported: %s (%T)", field.Name(), field.Kind(), field.Value())
 		}
 	case reflect.Float64:
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as float64: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(f); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Int64:
 		switch t := field.Value().(type) {
 		case time.Duration:
 			d, err := time.ParseDuration(v)
 			if err != nil {
-				return err
+				return fmt.Errorf("cannot parse value '%s' of field '%s' as duration: %w", v, field.Name(), err)
 			}
 
 			if err := field.Set(d); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		case int64:
-			p, err := strconv.ParseInt(v, 10, 0)
+			p, err := strconv.ParseInt(v, 10, 64)
 			if err != nil {
-				return err
+				return fmt.Errorf("cannot parse value '%s' of field '%s' as int64: %w", v, field.Name(), err)
 			}
 
 			if err := field.Set(p); err != nil {
-				return err
+				return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 			}
 		default:
-			return fmt.Errorf("multiconfig: field '%s' of type int64 is unsupported: %s (%T)",
+			return fmt.Errorf("field '%s' of type int64 is unsupported: %s (%T)",
 				field.Name(), field.Kind(), t)
 		}
 	case reflect.Uint:
-		u, err := strconv.ParseUint(v, 10, 0)
+		u, err := strconv.ParseUint(v, 10, strconv.IntSize)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(uint(u)); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Uint16:
 		u, err := strconv.ParseUint(v, 10, 16)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint16: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(uint16(u)); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Uint32:
 		u, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint32: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(uint32(u)); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	case reflect.Uint64:
 		u, err := strconv.ParseUint(v, 10, 64)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot parse value '%s' of field '%s' as uint64: %w", v, field.Name(), err)
 		}
 
 		if err := field.Set(u); err != nil {
-			return err
+			return fmt.Errorf("failed to set parsed value of field '%s': %w", field.Name(), err)
 		}
 	default:
-		return fmt.Errorf("multiconfig: field '%s' has unsupported type: %s", field.Name(), field.Kind())
+		return fmt.Errorf("field '%s' has unsupported type: %s", field.Name(), field.Kind())
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -32,8 +32,8 @@ github.com/davecgh/go-spew/spew
 # github.com/dustin/go-humanize v1.0.1
 ## explicit; go 1.16
 github.com/dustin/go-humanize
-# github.com/exoscale/multiconfig v0.0.0-20230329142724-71ec8bdb4f80
-## explicit; go 1.19
+# github.com/exoscale/multiconfig v0.0.0-20250121154433-cb30610932f6
+## explicit; go 1.22
 github.com/exoscale/multiconfig
 # github.com/fatih/camelcase v1.0.0
 ## explicit


### PR DESCRIPTION
Adds support for map[string]string and various map[string]int types in the flag, env and tag loader, bringing parity with the file loader.

Also updates the config of the metrics pusher to take advantage of the new map types.