### PR TITLE
http interceptor: In case of server error log with error level

### DIFF
--- a/fxlogging/interceptor/http.go
+++ b/fxlogging/interceptor/http.go
@@ -68,10 +68,19 @@ func NewRequestLogger(logger *zap.Logger, wrapped http.Handler) http.Handler {
 			return
 		}
 
-		l.Info(
-			"Handled request",
-			zap.Int("http.status", ww.StatusCode),
-			zap.Duration("http.duration", time.Since(start)),
-		)
+		if ww.StatusCode >= 500 {
+			l.Error(
+				"Handled request",
+				zap.Int("http.status", ww.StatusCode),
+				zap.Duration("http.duration", time.Since(start)),
+			)
+		} else {
+			l.Info(
+				"Handled request",
+				zap.Int("http.status", ww.StatusCode),
+				zap.Duration("http.duration", time.Since(start)),
+			)
+		}
+
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/exoscale/stelling
 
-go 1.22.7
-
-toolchain go1.23.6
+go 1.23.6
 
 require (
 	github.com/TheZeroSlave/zapsentry v1.23.0


### PR DESCRIPTION
I briefly considered putting client errors (4xx) as warning but I'm not sure it's that interesting 