### PR TITLE
Don't log caller in http logger interceptor: it makes no sense

### DIFF
--- a/fxlogging/interceptor/http.go
+++ b/fxlogging/interceptor/http.go
@@ -27,6 +27,7 @@ func (w *WrapResponseWriter) WriteHeader(statusCode int) {
 }
 
 func NewRequestLogger(logger *zap.Logger, wrapped http.Handler) http.Handler {
+	logger = logger.WithOptions(zap.WithCaller(false))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 


### PR DESCRIPTION
It's what we already do for our grpc interceptor logger