### PR TITLE
Also remove stracktraces from grpc client & server logger & http

### DIFF
--- a/fxlogging/interceptor/http.go
+++ b/fxlogging/interceptor/http.go
@@ -26,8 +26,14 @@ func (w *WrapResponseWriter) WriteHeader(statusCode int) {
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
+// NeverEnabler implements zapcore.LevelEnabler and always return false regardless of the level
+// This is used to disable features that are controlled by a zapcore.levelEnabler
+type NeverEnabler struct{}
+
+func (NeverEnabler) Enabled(zapcore.Level) bool { return false }
+
 func NewRequestLogger(logger *zap.Logger, wrapped http.Handler) http.Handler {
-	logger = logger.WithOptions(zap.WithCaller(false))
+	logger = logger.WithOptions(zap.WithCaller(false), zap.AddStacktrace(NeverEnabler{}))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 

--- a/fxlogging/logging.go
+++ b/fxlogging/logging.go
@@ -123,13 +123,14 @@ func ISO8601UTCTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 const GrpcInterceptorWeight uint = 50
 
 func NewGrpcLoggingServerInterceptors(logger *zap.Logger, opts ...interceptor.Option) (*fxgrpc.UnaryServerInterceptor, *fxgrpc.StreamServerInterceptor) {
+	logger = logger.WithOptions(zap.WithCaller(false), zap.AddStacktrace(interceptor.NeverEnabler{}))
 	unaryIx := &fxgrpc.UnaryServerInterceptor{Weight: GrpcInterceptorWeight, Interceptor: interceptor.NewLoggingUnaryServerInterceptor(logger, opts...)}
 	streamIx := &fxgrpc.StreamServerInterceptor{Weight: GrpcInterceptorWeight, Interceptor: interceptor.NewLoggingStreamServerInterceptor(logger, opts...)}
 	return unaryIx, streamIx
 }
 
 func NewGrpcLoggingClientInterceptors(logger *zap.Logger, opts ...interceptor.Option) (*fxgrpc.UnaryClientInterceptor, *fxgrpc.StreamClientInterceptor) {
-	logger = logger.WithOptions(zap.WithCaller(false))
+	logger = logger.WithOptions(zap.WithCaller(false), zap.AddStacktrace(interceptor.NeverEnabler{}))
 
 	unaryIx := &fxgrpc.UnaryClientInterceptor{Weight: GrpcInterceptorWeight, Interceptor: interceptor.NewLoggingUnaryClientInterceptor(logger, opts...)}
 	streamIx := &fxgrpc.StreamClientInterceptor{Weight: GrpcInterceptorWeight, Interceptor: interceptor.NewLoggingStreamClientInterceptor(logger, opts...)}


### PR DESCRIPTION
As a followup of #186 :

Ensure that all 3 logger interceptor (grpc client, grpc server & http server) don't log both the caller as well as the stacktrace in case of error

There's no relevant information here 