### PR TITLE
chore(lint): Update linter config to allow using embedded field names

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,17 @@ linters:
     - unconvert
     - unparam
     - wastedassign
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -QF1008 # Allow using name of embedded field in selector
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
   exclusions:
     generated: lax
     presets:

--- a/config/config_example_test.go
+++ b/config/config_example_test.go
@@ -34,7 +34,7 @@ type Config struct {
 // In this case it overwrites the default value for Port set by
 // the tags in ServerConfig
 func (c *Config) ApplyDefaults() {
-	c.Port = 9090
+	c.Server.Port = 9090
 }
 
 // In this example we'll show the order in which configuration is loaded

--- a/fxauthorizer/oidc/oidc_test.go
+++ b/fxauthorizer/oidc/oidc_test.go
@@ -158,7 +158,7 @@ func TestTokenExtractorExtract(t *testing.T) {
 
 		key, err := newRSAKey()
 		require.NoError(t, err)
-		token2, err := key.createIdToken(
+		token2, err := key.createIDToken(
 			"https://some.other.server",
 			"J. Doe",
 			"jdoe@example.com",
@@ -179,7 +179,7 @@ func TestTokenExtractorExtract(t *testing.T) {
 
 		key, err := newRSAKey()
 		require.NoError(t, err)
-		token2, err := key.createIdToken(
+		token2, err := key.createIDToken(
 			server.URL,
 			"J. Doe",
 			"jdoe@example.com",
@@ -199,7 +199,7 @@ func TestTokenExtractorExtract(t *testing.T) {
 
 	t.Run("Should return a parsed token", func(t *testing.T) {
 		server, key := setupOIDCTest(t, map[string]map[string]string{})
-		token, err := key.createIdToken(
+		token, err := key.createIDToken(
 			server.URL,
 			"J. Doe",
 			"jdoe@example.com",
@@ -219,7 +219,7 @@ func TestTokenExtractorExtract(t *testing.T) {
 	t.Run("Should return a parsed token from the configured header", func(t *testing.T) {
 		header := "Other-Header"
 		server, key := setupOIDCTest(t, map[string]map[string]string{})
-		token, err := key.createIdToken(
+		token, err := key.createIDToken(
 			server.URL,
 			"Jane Doe",
 			"janedoe@example.com",

--- a/fxauthorizer/oidc/test_oidc_server.go
+++ b/fxauthorizer/oidc/test_oidc_server.go
@@ -156,7 +156,7 @@ func (k *rsaKey) sign(payload []byte) (string, error) {
 	return data, nil
 }
 
-func (k *rsaKey) createIdToken(serverURL, user, email string, groups []string) (string, error) {
+func (k *rsaKey) createIDToken(serverURL, user, email string, groups []string) (string, error) {
 	input := []byte(`{
 		"iss": "` + serverURL + `",
 		"exp":` + strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10) + `,

--- a/fxmetrics/metrics.go
+++ b/fxmetrics/metrics.go
@@ -47,7 +47,7 @@ type Metrics struct {
 }
 
 func (m *Metrics) ApplyDefaults() {
-	m.Address = ":9091"
+	m.Server.Address = ":9091"
 }
 
 func (m *Metrics) MetricsConfig() *Metrics {


### PR DESCRIPTION
We use embedded fields extensively in stelling modules to eliminate boilerplate when creating the fx system.
However when referencing config values it is often much clearer to use the name of the embedded struct when referencing a field. We therefore disable this linter check.