### PR TITLE
chore(lint): Make net.Listen context aware

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
-	github.com/getsentry/sentry-go v0.32.0 // indirect
+	github.com/getsentry/sentry-go v0.33.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
@@ -69,7 +69,7 @@ require (
 	golang.org/x/text v0.24.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34 // indirect
-	google.golang.org/grpc v1.72.0 // indirect
+	google.golang.org/grpc v1.72.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -22,8 +22,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
-github.com/getsentry/sentry-go v0.32.0 h1:YKs+//QmwE3DcYtfKRH8/KyOOF/I6Qnx7qYGNHCGmCY=
-github.com/getsentry/sentry-go v0.32.0/go.mod h1:CYNcMMz73YigoHljQRG+qPF+eMq8gG72XcGN/p71BAY=
+github.com/getsentry/sentry-go v0.33.0 h1:YWyDii0KGVov3xOaamOnF0mjOrqSjBqwv48UEzn7QFg=
+github.com/getsentry/sentry-go v0.33.0/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -139,8 +139,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34/go.mod h1:0awUlEkap+Pb1UMeJwJQQAdJQrt3moU7J2moTy69irI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34 h1:h6p3mQqrmT1XkHVTfzLdNz1u7IhINeZkz67/xTbOuWs=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
-google.golang.org/grpc v1.72.0 h1:S7UkcVa60b5AAQTaO6ZKamFp1zMZSU0fGDK2WZLbBnM=
-google.golang.org/grpc v1.72.0/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
+google.golang.org/grpc v1.72.1 h1:HR03wO6eyZ7lknl75XlxABNVLLFc2PAb6mHlYh756mA=
+google.golang.org/grpc v1.72.1/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/grpc/examples v0.0.0-20250429054939-399e2d048c20 h1:XUpdWlbl7tEGFc7D4K6+WJsVtwQ5a/goCmlw6kFyyrQ=
 google.golang.org/grpc/examples v0.0.0-20250429054939-399e2d048c20/go.mod h1:WPWnet+nYurNGpV0rVYHI1YuOJwVHeM3t8f76m410XM=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=

--- a/examples/vendor/github.com/exoscale/stelling/fxgrpc/README.md
+++ b/examples/vendor/github.com/exoscale/stelling/fxgrpc/README.md
@@ -63,6 +63,30 @@ The module provides the following configuration options:
 
 The client can further be customized by providing [grpc.DialOption](https://pkg.go.dev/google.golang.org/grpc#DialOption) in the `grpc_client_options` value group.
 
+## ConnManager
+
+### Components
+The module lazily provides the following components:
+
+* A `*fxgrpc.ConnManager`
+
+This is a cache of `*grpc.ClientConn` to an endpoint.
+Each connection has the same features as a regular gRPC client produced by stelling (TLS management, interceptors, etc.)
+
+The interface is very simple: `manager.Get(endpoint)` will return a `*grpc.ClientConn` to that endpoint.
+Since connections can be used by multiple clients, there's no reason to return them to the manager.
+Grpc will automatically close and recreate any underlying TCP connections depending on usage.
+
+### Configuration
+The module provides the following configuration options:
+
+* `InsecureConnection`: Disables TLS when connecting to the server
+* `CertFile`: Path to a pem encoded client TLS certificate
+* `KeyFile`: Path to the pem encoded private key of the client TLS certificate
+* `RootCAFile`: Path to a pem encoded CA bundle to validate the server certificate
+
+The connections can further be customized by providing [grpc.DialOption](https://pkg.go.dev/google.golang.org/grpc#DialOption) in the `grpc_client_options` value group.
+
 ## Interceptors
 Because grpc interceptors form a chain, the order in which they are installed on the server or client is important.
 

--- a/examples/vendor/github.com/exoscale/stelling/fxgrpc/conn_manager.go
+++ b/examples/vendor/github.com/exoscale/stelling/fxgrpc/conn_manager.go
@@ -1,0 +1,151 @@
+package fxgrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	fxcert_reloader "github.com/exoscale/stelling/fxcert-reloader"
+	"go.uber.org/fx"
+	"google.golang.org/grpc"
+)
+
+func NewConnManagerModule(conf ConnManagerConfig) fx.Option {
+	return fx.Module(
+		"grpc-conn-manager",
+		fx.Supply(fx.Annotate(conf, fx.As(new(ConnManagerConfig)))),
+		fx.Provide(
+			fx.Annotate(
+				func(conf ConnManagerConfig) ClientConfig {
+					return &Client{
+						InsecureConnection: conf.ConnManagerConfig().InsecureConnection,
+						CertFile:           conf.ConnManagerConfig().CertFile,
+						KeyFile:            conf.ConnManagerConfig().KeyFile,
+						RootCAFile:         conf.ConnManagerConfig().RootCAFile,
+					}
+				},
+				fx.ResultTags(`name:"grpc_conn_manager"`),
+			),
+			fx.Annotate(
+				MakeClientTLS,
+				fx.ParamTags(`name:"grpc_conn_manager"`),
+				fx.ResultTags(``, `name:"grpc_conn_manager"`),
+			),
+			fx.Annotate(
+				grpc.WithTransportCredentials,
+				fx.ResultTags(`group:"grpc_client_options"`),
+			),
+			fx.Annotate(
+				WithStreamClientInterceptors,
+				fx.ParamTags(`group:"stream_client_interceptors"`),
+				fx.ResultTags(`group:"grpc_client_options"`),
+			),
+			fx.Annotate(
+				WithUnaryClientInterceptors,
+				fx.ParamTags(`group:"unary_client_interceptors"`),
+				fx.ResultTags(`group:"grpc_client_options"`),
+			),
+			fx.Private,
+		),
+		fx.Provide(
+			ProvideConnManager,
+		),
+	)
+}
+
+type ConnManagerConfig interface {
+	ConnManagerConfig() *ConnManagerOpts
+}
+
+type ConnManagerOpts struct {
+	// InsecureConnection indicates whether TLS needs to be disabled when connecting to the grpc server
+	InsecureConnection bool
+	// CertFile is the path to the pem encoded TLS certificate
+	CertFile string `validate:"omitempty,file"`
+	// KeyFile is the path to the pem encoded private key of the TLS certificate
+	KeyFile string `validate:"required_with=CertFile,omitempty,file"`
+	// RootCAFile is the  path to a pem encoded CA bundle used to validate server connections
+	RootCAFile string `validate:"omitempty,file"`
+}
+
+func (c *ConnManagerOpts) ConnManagerConfig() *ConnManagerOpts {
+	return c
+}
+
+// ConnManager is a cache of grpc.ClientConn's
+// Users of the manager should leave the lifecycle of the
+// underlying gRPC connections entirely up to the manager
+type ConnManager struct {
+	lock sync.RWMutex
+	idx  map[string]*grpc.ClientConn
+	opts []grpc.DialOption
+}
+
+func NewConnManager(opts []grpc.DialOption) *ConnManager {
+	return &ConnManager{
+		idx:  make(map[string]*grpc.ClientConn),
+		opts: opts,
+	}
+}
+
+func (m *ConnManager) Stop(ctx context.Context) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	var errs error
+	for _, conn := range m.idx {
+		if err := conn.Close(); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+	return errs
+}
+
+type ConnManagerParams struct {
+	fx.In
+
+	Lc                 fx.Lifecycle
+	Opts               []grpc.DialOption             `group:"grpc_client_options"`
+	Reloader           *fxcert_reloader.CertReloader `optional:"true" name:"grpc_conn_manager"`
+	UnaryInterceptors  []*UnaryClientInterceptor     `group:"unary_client_interceptor"`
+	StreamInterceptors []*StreamClientInterceptor    `group:"stream_client_interceptor"`
+}
+
+func ProvideConnManager(p ConnManagerParams) *ConnManager {
+	if p.Reloader != nil {
+		p.Lc.Append(fx.Hook{OnStart: p.Reloader.Start, OnStop: p.Reloader.Stop})
+	}
+	output := NewConnManager(append(
+		p.Opts,
+		WithUnaryClientInterceptors(p.UnaryInterceptors),
+		WithStreamClientInterceptors(p.StreamInterceptors),
+	))
+	p.Lc.Append(fx.Hook{OnStop: output.Stop})
+	return output
+}
+
+func (m *ConnManager) Get(address string) (*grpc.ClientConn, error) {
+	m.lock.RLock()
+	conn, ok := m.idx[address]
+	m.lock.RUnlock()
+	if !ok {
+		return m.createConnection(address)
+	}
+	return conn, nil
+}
+
+func (m *ConnManager) createConnection(address string) (*grpc.ClientConn, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	// Check again, to avoid a race condition where we try to create the same connection concurrently
+	conn, ok := m.idx[address]
+	if ok {
+		return conn, nil
+	}
+	conn, err := grpc.NewClient(address, m.opts...)
+	if err != nil {
+		return nil, fmt.Errorf("clientManager: createConnection: %w", err)
+	}
+	m.idx[address] = conn
+	return conn, nil
+}

--- a/examples/vendor/github.com/exoscale/stelling/fxmetrics/README.md
+++ b/examples/vendor/github.com/exoscale/stelling/fxmetrics/README.md
@@ -19,7 +19,7 @@ Additional custom metrics can of course be registered.
 
 ## Regular Module
 
-### Components 
+### Components
 The module lazily provides the following components:
 
 * A `*prometheus.Registry`
@@ -30,7 +30,7 @@ It starts an additional webserver exposing the prometheus endpoint.
 
 ## OTLP Module
 
-### Components 
+### Components
 The module lazily provides the following components:
 
 * A `*prometheus.Registry`
@@ -68,8 +68,7 @@ It adds hooks to push the metrics when the system stops and at regular intervals
 * `Histograms`: A bool which enables support for histograms in the grpc middleware (will most likely be removed)
 * `ProcessName`: A string used as a prefix inside the process collector to prevent clashes
 * `JobName`: The name of the job in pushgateway
-* `GroupingLabelKey`: The label on which pushgateway groups metrics
-  Pushgateway keeps a copy of each metric for each value of GroupingLabelKey
-* `GroupingLabelValue`: The value for this instance of the GroupingLabelKey
-* `PushInterval`: The frequency at which metrics are pushed during runtime. 
+* `GroupingLabels`: A map of label name & values
+  Pushgateway keeps a copy of each metric for each value of the set of grouping label keys
+* `PushInterval`: The frequency at which metrics are pushed during runtime.
   When `0` metrics are only pushed when the system stops

--- a/examples/vendor/github.com/getsentry/sentry-go/.codecov.yml
+++ b/examples/vendor/github.com/getsentry/sentry-go/.codecov.yml
@@ -11,3 +11,5 @@ coverage:
       default:
         # Do not fail the commit status if the coverage was reduced up to this value
         threshold: 0.5%
+ignore:
+  - "log_fallback.go"

--- a/examples/vendor/github.com/getsentry/sentry-go/.golangci.yml
+++ b/examples/vendor/github.com/getsentry/sentry-go/.golangci.yml
@@ -1,20 +1,17 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -22,25 +19,44 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - goconst
-        - prealloc
-    - path: _test\.go
-      text: "G306:"
-      linters:
-        - gosec
-    - path: errors_test\.go
-      linters:
-        - unused
-    - path: http/example_test\.go
-      linters:
-        - errcheck
-        - bodyclose
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - goconst
+          - prealloc
+        path: _test\.go
+      - linters:
+          - gosec
+        path: _test\.go
+        text: 'G306:'
+      - linters:
+          - unused
+        path: errors_test\.go
+      - linters:
+          - bodyclose
+          - errcheck
+        path: http/example_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/examples/vendor/github.com/getsentry/sentry-go/CHANGELOG.md
+++ b/examples/vendor/github.com/getsentry/sentry-go/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.33.0
+
+The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.33.0.
+
+
+### Breaking Changes
+
+- Rename the internal `Logger` to `DebugLogger`. This feature was only used when you set `Debug: True` in your `sentry.Init()` call. If you haven't used the Logger directly, no changes are necessary. ([#1012](https://github.com/getsentry/sentry-go/issues/1012))
+
+### Features
+
+- Add support for [Structured Logging](https://docs.sentry.io/product/explore/logs/). ([#1010](https://github.com/getsentry/sentry-go/issues/1010))
+
+  ```go
+  logger := sentry.NewLogger(ctx)
+  logger.Info(ctx, "Hello, Logs!")
+  ```
+
+  You can learn more about Sentry Logs on our [docs](https://docs.sentry.io/product/explore/logs/) and the [examples](https://github.com/getsentry/sentry-go/blob/master/_examples/logs/main.go).
+
+- Add new attributes APIs, which are currently only exposed on logs. ([#1007](https://github.com/getsentry/sentry-go/issues/1007))
+
+### Bug Fixes
+
+- Do not push a new scope on `StartSpan`. ([#1013](https://github.com/getsentry/sentry-go/issues/1013))
+- Fix an issue where the propagated smapling decision wasn't used. ([#995](https://github.com/getsentry/sentry-go/issues/995))
+- [Otel] Prefer `httpRoute` over `httpTarget` for span descriptions. ([#1002](https://github.com/getsentry/sentry-go/issues/1002))
+
+### Misc
+
+- Update `github.com/stretchr/testify` to v1.8.4. ([#988](https://github.com/getsentry/sentry-go/issues/988))  
+
 ## 0.32.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Go SDK v0.32.0.

--- a/examples/vendor/github.com/getsentry/sentry-go/attribute/bulider.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/attribute/bulider.go
@@ -1,0 +1,36 @@
+package attribute
+
+type Builder struct {
+	Key   string
+	Value Value
+}
+
+// String returns a Builder for a string value.
+func String(key, value string) Builder {
+	return Builder{key, StringValue(value)}
+}
+
+// Int64 returns a Builder for an int64.
+func Int64(key string, value int64) Builder {
+	return Builder{key, Int64Value(value)}
+}
+
+// Int returns a Builder for an int64.
+func Int(key string, value int) Builder {
+	return Builder{key, IntValue(value)}
+}
+
+// Float64 returns a Builder for a float64.
+func Float64(key string, v float64) Builder {
+	return Builder{key, Float64Value(v)}
+}
+
+// Bool returns a Builder for a boolean.
+func Bool(key string, v bool) Builder {
+	return Builder{key, BoolValue(v)}
+}
+
+// Valid checks for valid key and type.
+func (b *Builder) Valid() bool {
+	return len(b.Key) > 0 && b.Value.Type() != INVALID
+}

--- a/examples/vendor/github.com/getsentry/sentry-go/attribute/rawhelpers.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/attribute/rawhelpers.go
@@ -1,0 +1,49 @@
+// Copied from https://github.com/open-telemetry/opentelemetry-go/blob/cc43e01c27892252aac9a8f20da28cdde957a289/attribute/rawhelpers.go
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"math"
+)
+
+func boolToRaw(b bool) uint64 { // b is not a control flag.
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func rawToBool(r uint64) bool {
+	return r != 0
+}
+
+func int64ToRaw(i int64) uint64 {
+	// Assumes original was a valid int64 (overflow not checked).
+	return uint64(i) // nolint: gosec
+}
+
+func rawToInt64(r uint64) int64 {
+	// Assumes original was a valid int64 (overflow not checked).
+	return int64(r) // nolint: gosec
+}
+
+func float64ToRaw(f float64) uint64 {
+	return math.Float64bits(f)
+}
+
+func rawToFloat64(r uint64) float64 {
+	return math.Float64frombits(r)
+}

--- a/examples/vendor/github.com/getsentry/sentry-go/attribute/value.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/attribute/value.go
@@ -1,0 +1,170 @@
+// Adapted from https://github.com/open-telemetry/opentelemetry-go/blob/cc43e01c27892252aac9a8f20da28cdde957a289/attribute/value.go
+//
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Type describes the type of the data Value holds.
+type Type int // redefines builtin Type.
+
+// Value represents the value part in key-value pairs.
+type Value struct {
+	vtype    Type
+	numeric  uint64
+	stringly string
+}
+
+const (
+	// INVALID is used for a Value with no value set.
+	INVALID Type = iota
+	// BOOL is a boolean Type Value.
+	BOOL
+	// INT64 is a 64-bit signed integral Type Value.
+	INT64
+	// FLOAT64 is a 64-bit floating point Type Value.
+	FLOAT64
+	// STRING is a string Type Value.
+	STRING
+)
+
+// BoolValue creates a BOOL Value.
+func BoolValue(v bool) Value {
+	return Value{
+		vtype:   BOOL,
+		numeric: boolToRaw(v),
+	}
+}
+
+// IntValue creates an INT64 Value.
+func IntValue(v int) Value {
+	return Int64Value(int64(v))
+}
+
+// Int64Value creates an INT64 Value.
+func Int64Value(v int64) Value {
+	return Value{
+		vtype:   INT64,
+		numeric: int64ToRaw(v),
+	}
+}
+
+// Float64Value creates a FLOAT64 Value.
+func Float64Value(v float64) Value {
+	return Value{
+		vtype:   FLOAT64,
+		numeric: float64ToRaw(v),
+	}
+}
+
+// StringValue creates a STRING Value.
+func StringValue(v string) Value {
+	return Value{
+		vtype:    STRING,
+		stringly: v,
+	}
+}
+
+// Type returns a type of the Value.
+func (v Value) Type() Type {
+	return v.vtype
+}
+
+// AsBool returns the bool value. Make sure that the Value's type is
+// BOOL.
+func (v Value) AsBool() bool {
+	return rawToBool(v.numeric)
+}
+
+// AsInt64 returns the int64 value. Make sure that the Value's type is
+// INT64.
+func (v Value) AsInt64() int64 {
+	return rawToInt64(v.numeric)
+}
+
+// AsFloat64 returns the float64 value. Make sure that the Value's
+// type is FLOAT64.
+func (v Value) AsFloat64() float64 {
+	return rawToFloat64(v.numeric)
+}
+
+// AsString returns the string value. Make sure that the Value's type
+// is STRING.
+func (v Value) AsString() string {
+	return v.stringly
+}
+
+type unknownValueType struct{}
+
+// AsInterface returns Value's data as interface{}.
+func (v Value) AsInterface() interface{} {
+	switch v.Type() {
+	case BOOL:
+		return v.AsBool()
+	case INT64:
+		return v.AsInt64()
+	case FLOAT64:
+		return v.AsFloat64()
+	case STRING:
+		return v.stringly
+	}
+	return unknownValueType{}
+}
+
+// String returns a string representation of Value's data.
+func (v Value) String() string {
+	switch v.Type() {
+	case BOOL:
+		return strconv.FormatBool(v.AsBool())
+	case INT64:
+		return strconv.FormatInt(v.AsInt64(), 10)
+	case FLOAT64:
+		return fmt.Sprint(v.AsFloat64())
+	case STRING:
+		return v.stringly
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON returns the JSON encoding of the Value.
+func (v Value) MarshalJSON() ([]byte, error) {
+	var jsonVal struct {
+		Type  string
+		Value interface{}
+	}
+	jsonVal.Type = v.Type().String()
+	jsonVal.Value = v.AsInterface()
+	return json.Marshal(jsonVal)
+}
+
+func (t Type) String() string {
+	switch t {
+	case BOOL:
+		return "bool"
+	case INT64:
+		return "int64"
+	case FLOAT64:
+		return "float64"
+	case STRING:
+		return "string"
+	}
+	return "invalid"
+}

--- a/examples/vendor/github.com/getsentry/sentry-go/batch_logger.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/batch_logger.go
@@ -1,0 +1,94 @@
+package sentry
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const (
+	batchSize    = 100
+	batchTimeout = 5 * time.Second
+)
+
+type BatchLogger struct {
+	client    *Client
+	logCh     chan Log
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	startOnce sync.Once
+}
+
+func NewBatchLogger(client *Client) *BatchLogger {
+	return &BatchLogger{
+		client: client,
+		logCh:  make(chan Log, batchSize),
+	}
+}
+
+func (l *BatchLogger) Start() {
+	l.startOnce.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		l.cancel = cancel
+		l.wg.Add(1)
+		go l.run(ctx)
+	})
+}
+
+func (l *BatchLogger) Flush() {
+	if l.cancel != nil {
+		l.cancel()
+		l.wg.Wait()
+	}
+}
+
+func (l *BatchLogger) run(ctx context.Context) {
+	defer l.wg.Done()
+	var logs []Log
+	timer := time.NewTimer(batchTimeout)
+
+	for {
+		select {
+		case log := <-l.logCh:
+			logs = append(logs, log)
+			if len(logs) >= batchSize {
+				l.processEvent(logs)
+				logs = nil
+				if !timer.Stop() {
+					<-timer.C
+				}
+				timer.Reset(batchTimeout)
+			}
+		case <-timer.C:
+			if len(logs) > 0 {
+				l.processEvent(logs)
+				logs = nil
+			}
+			timer.Reset(batchTimeout)
+		case <-ctx.Done():
+			// Drain remaining logs from channel
+		drain:
+			for {
+				select {
+				case log := <-l.logCh:
+					logs = append(logs, log)
+				default:
+					break drain
+				}
+			}
+
+			if len(logs) > 0 {
+				l.processEvent(logs)
+			}
+			return
+		}
+	}
+}
+
+func (l *BatchLogger) processEvent(logs []Log) {
+	event := NewEvent()
+	event.Timestamp = time.Now()
+	event.Type = logEvent.Type
+	event.Logs = logs
+	l.client.CaptureEvent(event, nil, nil)
+}

--- a/examples/vendor/github.com/getsentry/sentry-go/client.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/client.go
@@ -77,9 +77,9 @@ type usageError struct {
 	error
 }
 
-// Logger is an instance of log.Logger that is use to provide debug information about running Sentry Client
-// can be enabled by either using Logger.SetOutput directly or with Debug client option.
-var Logger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
+// DebugLogger is an instance of log.Logger that is used to provide debug information about running Sentry Client
+// can be enabled by either using DebugLogger.SetOutput directly or with Debug client option.
+var DebugLogger = log.New(io.Discard, "[Sentry] ", log.LstdFlags)
 
 // EventProcessor is a function that processes an event.
 // Event processors are used to change an event before it is sent to Sentry.
@@ -144,8 +144,11 @@ type ClientOptions struct {
 	// By default, no such data is sent.
 	SendDefaultPII bool
 	// BeforeSend is called before error events are sent to Sentry.
-	// Use it to mutate the event or return nil to discard the event.
+	// You can use it to mutate the event or return nil to discard it.
 	BeforeSend func(event *Event, hint *EventHint) *Event
+	// BeforeSendLong is called before log events are sent to Sentry.
+	// You can use it to mutate the log event or return nil to discard it.
+	BeforeSendLog func(event *Log) *Log
 	// BeforeSendTransaction is called before transaction events are sent to Sentry.
 	// Use it to mutate the transaction or return nil to discard the transaction.
 	BeforeSendTransaction func(event *Event, hint *EventHint) *Event
@@ -223,6 +226,8 @@ type ClientOptions struct {
 	MaxErrorDepth int
 	// Default event tags. These are overridden by tags set on a scope.
 	Tags map[string]string
+	// EnableLogs controls when logs should be emitted.
+	EnableLogs bool
 }
 
 // Client is the underlying processor that is used by the main API and Hub
@@ -237,7 +242,8 @@ type Client struct {
 	sdkVersion      string
 	// Transport is read-only. Replacing the transport of an existing client is
 	// not supported, create a new client instead.
-	Transport Transport
+	Transport   Transport
+	batchLogger *BatchLogger
 }
 
 // NewClient creates and returns an instance of Client configured using
@@ -275,7 +281,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 		if debugWriter == nil {
 			debugWriter = os.Stderr
 		}
-		Logger.SetOutput(debugWriter)
+		DebugLogger.SetOutput(debugWriter)
 	}
 
 	if options.Dsn == "" {
@@ -337,6 +343,11 @@ func NewClient(options ClientOptions) (*Client, error) {
 		sdkVersion:    SDKVersion,
 	}
 
+	if options.EnableLogs {
+		client.batchLogger = NewBatchLogger(&client)
+		client.batchLogger.Start()
+	}
+
 	client.setupTransport()
 	client.setupIntegrations()
 
@@ -351,15 +362,7 @@ func (client *Client) setupTransport() {
 		if opts.Dsn == "" {
 			transport = new(noopTransport)
 		} else {
-			httpTransport := NewHTTPTransport()
-			// When tracing is enabled, use larger buffer to
-			// accommodate more concurrent events.
-			// TODO(tracing): consider using separate buffers per
-			// event type.
-			if opts.EnableTracing {
-				httpTransport.BufferSize = 1000
-			}
-			transport = httpTransport
+			transport = NewHTTPTransport()
 		}
 	}
 
@@ -383,12 +386,12 @@ func (client *Client) setupIntegrations() {
 
 	for _, integration := range integrations {
 		if client.integrationAlreadyInstalled(integration.Name()) {
-			Logger.Printf("Integration %s is already installed\n", integration.Name())
+			DebugLogger.Printf("Integration %s is already installed\n", integration.Name())
 			continue
 		}
 		client.integrations = append(client.integrations, integration)
 		integration.SetupOnce(client)
-		Logger.Printf("Integration installed: %s\n", integration.Name())
+		DebugLogger.Printf("Integration installed: %s\n", integration.Name())
 	}
 
 	sort.Slice(client.integrations, func(i, j int) bool {
@@ -507,6 +510,9 @@ func (client *Client) RecoverWithContext(
 // the network synchronously, configure it to use the HTTPSyncTransport in the
 // call to Init.
 func (client *Client) Flush(timeout time.Duration) bool {
+	if client.batchLogger != nil {
+		client.batchLogger.Flush()
+	}
 	return client.Transport.Flush(timeout)
 }
 
@@ -605,7 +611,7 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	// options.TracesSampler when they are started. Other events
 	// (errors, messages) are sampled here. Does not apply to check-ins.
 	if event.Type != transactionType && event.Type != checkInType && !sample(client.options.SampleRate) {
-		Logger.Println("Event dropped due to SampleRate hit.")
+		DebugLogger.Println("Event dropped due to SampleRate hit.")
 		return nil
 	}
 
@@ -617,17 +623,21 @@ func (client *Client) processEvent(event *Event, hint *EventHint, scope EventMod
 	if hint == nil {
 		hint = &EventHint{}
 	}
-	if event.Type == transactionType && client.options.BeforeSendTransaction != nil {
-		// Transaction events
-		if event = client.options.BeforeSendTransaction(event, hint); event == nil {
-			Logger.Println("Transaction dropped due to BeforeSendTransaction callback.")
-			return nil
+	switch event.Type {
+	case transactionType:
+		if client.options.BeforeSendTransaction != nil {
+			if event = client.options.BeforeSendTransaction(event, hint); event == nil {
+				DebugLogger.Println("Transaction dropped due to BeforeSendTransaction callback.")
+				return nil
+			}
 		}
-	} else if event.Type != transactionType && event.Type != checkInType && client.options.BeforeSend != nil {
-		// All other events
-		if event = client.options.BeforeSend(event, hint); event == nil {
-			Logger.Println("Event dropped due to BeforeSend callback.")
-			return nil
+	case checkInType: // not a default case, since we shouldn't apply BeforeSend on check-in events
+	default:
+		if client.options.BeforeSend != nil {
+			if event = client.options.BeforeSend(event, hint); event == nil {
+				DebugLogger.Println("Event dropped due to BeforeSend callback.")
+				return nil
+			}
 		}
 	}
 
@@ -692,7 +702,7 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			Logger.Printf("Event dropped by one of the Client EventProcessors: %s\n", id)
+			DebugLogger.Printf("Event dropped by one of the Client EventProcessors: %s\n", id)
 			return nil
 		}
 	}
@@ -701,7 +711,7 @@ func (client *Client) prepareEvent(event *Event, hint *EventHint, scope EventMod
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			Logger.Printf("Event dropped by one of the Global EventProcessors: %s\n", id)
+			DebugLogger.Printf("Event dropped by one of the Global EventProcessors: %s\n", id)
 			return nil
 		}
 	}

--- a/examples/vendor/github.com/getsentry/sentry-go/hub.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/hub.go
@@ -308,7 +308,7 @@ func (hub *Hub) AddBreadcrumb(breadcrumb *Breadcrumb, hint *BreadcrumbHint) {
 			hint = &BreadcrumbHint{}
 		}
 		if breadcrumb = client.options.BeforeBreadcrumb(breadcrumb, hint); breadcrumb == nil {
-			Logger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
+			DebugLogger.Println("breadcrumb dropped due to BeforeBreadcrumb callback.")
 			return
 		}
 	}

--- a/examples/vendor/github.com/getsentry/sentry-go/integrations.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/integrations.go
@@ -32,7 +32,7 @@ func (mi *modulesIntegration) processor(event *Event, _ *EventHint) *Event {
 		mi.once.Do(func() {
 			info, ok := debug.ReadBuildInfo()
 			if !ok {
-				Logger.Print("The Modules integration is not available in binaries built without module support.")
+				DebugLogger.Print("The Modules integration is not available in binaries built without module support.")
 				return
 			}
 			mi.modules = extractModules(info)
@@ -141,7 +141,7 @@ func (iei *ignoreErrorsIntegration) processor(event *Event, _ *EventHint) *Event
 	for _, suspect := range suspects {
 		for _, pattern := range iei.ignoreErrors {
 			if pattern.Match([]byte(suspect)) || strings.Contains(suspect, pattern.String()) {
-				Logger.Printf("Event dropped due to being matched by `IgnoreErrors` option."+
+				DebugLogger.Printf("Event dropped due to being matched by `IgnoreErrors` option."+
 					"| Value matched: %s | Filter used: %s", suspect, pattern)
 				return nil
 			}
@@ -203,7 +203,7 @@ func (iei *ignoreTransactionsIntegration) processor(event *Event, _ *EventHint) 
 
 	for _, pattern := range iei.ignoreTransactions {
 		if pattern.Match([]byte(suspect)) || strings.Contains(suspect, pattern.String()) {
-			Logger.Printf("Transaction dropped due to being matched by `IgnoreTransactions` option."+
+			DebugLogger.Printf("Transaction dropped due to being matched by `IgnoreTransactions` option."+
 				"| Value matched: %s | Filter used: %s", suspect, pattern)
 			return nil
 		}

--- a/examples/vendor/github.com/getsentry/sentry-go/log.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/log.go
@@ -1,0 +1,216 @@
+package sentry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go/attribute"
+)
+
+type LogLevel string
+
+const (
+	LogLevelTrace Level = "trace"
+	LogLevelDebug Level = "debug"
+	LogLevelInfo  Level = "info"
+	LogLevelWarn  Level = "warn"
+	LogLevelError Level = "error"
+	LogLevelFatal Level = "fatal"
+)
+
+const (
+	LogSeverityTrace   int = 1
+	LogSeverityDebug   int = 5
+	LogSeverityInfo    int = 9
+	LogSeverityWarning int = 13
+	LogSeverityError   int = 17
+	LogSeverityFatal   int = 21
+)
+
+var mapTypesToStr = map[attribute.Type]string{
+	attribute.INVALID: "",
+	attribute.BOOL:    "boolean",
+	attribute.INT64:   "integer",
+	attribute.FLOAT64: "double",
+	attribute.STRING:  "string",
+}
+
+type sentryLogger struct {
+	client     *Client
+	attributes map[string]Attribute
+}
+
+// NewLogger returns a Logger that emits logs to Sentry. If logging is turned off, all logs get discarded.
+func NewLogger(ctx context.Context) Logger {
+	var hub *Hub
+	hub = GetHubFromContext(ctx)
+	if hub == nil {
+		hub = CurrentHub()
+	}
+
+	client := hub.Client()
+	if client != nil && client.batchLogger != nil {
+		return &sentryLogger{client, make(map[string]Attribute)}
+	}
+
+	DebugLogger.Println("fallback to noopLogger: enableLogs disabled")
+	return &noopLogger{} // fallback: does nothing
+}
+
+func (l *sentryLogger) Write(p []byte) (int, error) {
+	// Avoid sending double newlines to Sentry
+	msg := strings.TrimRight(string(p), "\n")
+	l.log(context.Background(), LevelInfo, LogSeverityInfo, msg)
+	return len(p), nil
+}
+
+func (l *sentryLogger) log(ctx context.Context, level Level, severity int, message string, args ...interface{}) {
+	if message == "" {
+		return
+	}
+	hub := GetHubFromContext(ctx)
+	if hub == nil {
+		hub = CurrentHub()
+	}
+
+	var traceID TraceID
+	var spanID SpanID
+
+	span := hub.Scope().span
+	if span != nil {
+		traceID = span.TraceID
+		spanID = span.SpanID
+	} else {
+		traceID = hub.Scope().propagationContext.TraceID
+	}
+
+	attrs := map[string]Attribute{}
+	if len(args) > 0 {
+		attrs["sentry.message.template"] = Attribute{
+			Value: message, Type: "string",
+		}
+		for i, p := range args {
+			attrs[fmt.Sprintf("sentry.message.parameters.%d", i)] = Attribute{
+				Value: fmt.Sprint(p), Type: "string",
+			}
+		}
+	}
+
+	// If `log` was called with SetAttributes, pass the attributes to attrs
+	if len(l.attributes) > 0 {
+		for k, v := range l.attributes {
+			attrs[k] = v
+		}
+		// flush attributes from logger after send
+		clear(l.attributes)
+	}
+
+	// Set default attributes
+	if release := l.client.options.Release; release != "" {
+		attrs["sentry.release"] = Attribute{Value: release, Type: "string"}
+	}
+	if environment := l.client.options.Environment; environment != "" {
+		attrs["sentry.environment"] = Attribute{Value: environment, Type: "string"}
+	}
+	if serverName := l.client.options.ServerName; serverName != "" {
+		attrs["sentry.server.address"] = Attribute{Value: serverName, Type: "string"}
+	} else if serverAddr, err := os.Hostname(); err == nil {
+		attrs["sentry.server.address"] = Attribute{Value: serverAddr, Type: "string"}
+	}
+	if spanID.String() != "0000000000000000" {
+		attrs["sentry.trace.parent_span_id"] = Attribute{Value: spanID.String(), Type: "string"}
+	}
+	if sdkIdentifier := l.client.sdkIdentifier; sdkIdentifier != "" {
+		attrs["sentry.sdk.name"] = Attribute{Value: sdkIdentifier, Type: "string"}
+	}
+	if sdkVersion := l.client.sdkVersion; sdkVersion != "" {
+		attrs["sentry.sdk.version"] = Attribute{Value: sdkVersion, Type: "string"}
+	}
+	attrs["sentry.origin"] = Attribute{Value: "auto.logger.log", Type: "string"}
+
+	log := &Log{
+		Timestamp:  time.Now(),
+		TraceID:    traceID,
+		Level:      level,
+		Severity:   severity,
+		Body:       fmt.Sprintf(message, args...),
+		Attributes: attrs,
+	}
+
+	if l.client.options.BeforeSendLog != nil {
+		log = l.client.options.BeforeSendLog(log)
+	}
+
+	if log != nil {
+		l.client.batchLogger.logCh <- *log
+	}
+
+	if l.client.options.Debug {
+		DebugLogger.Printf(message, args...)
+	}
+}
+
+func (l *sentryLogger) SetAttributes(attrs ...attribute.Builder) {
+	for _, v := range attrs {
+		t, ok := mapTypesToStr[v.Value.Type()]
+		if !ok || t == "" {
+			DebugLogger.Printf("invalid attribute type set: %v", t)
+			continue
+		}
+
+		l.attributes[v.Key] = Attribute{
+			Value: v.Value.AsInterface(),
+			Type:  t,
+		}
+	}
+}
+
+func (l *sentryLogger) Trace(ctx context.Context, v ...interface{}) {
+	l.log(ctx, LogLevelTrace, LogSeverityTrace, fmt.Sprint(v...))
+}
+func (l *sentryLogger) Debug(ctx context.Context, v ...interface{}) {
+	l.log(ctx, LogLevelDebug, LogSeverityDebug, fmt.Sprint(v...))
+}
+func (l *sentryLogger) Info(ctx context.Context, v ...interface{}) {
+	l.log(ctx, LogLevelInfo, LogSeverityInfo, fmt.Sprint(v...))
+}
+func (l *sentryLogger) Warn(ctx context.Context, v ...interface{}) {
+	l.log(ctx, LogLevelWarn, LogSeverityWarning, fmt.Sprint(v...))
+}
+func (l *sentryLogger) Error(ctx context.Context, v ...interface{}) {
+	l.log(ctx, LogLevelError, LogSeverityError, fmt.Sprint(v...))
+}
+func (l *sentryLogger) Fatal(ctx context.Context, v ...interface{}) {
+	l.log(ctx, LogLevelFatal, LogSeverityFatal, fmt.Sprint(v...))
+	os.Exit(1)
+}
+func (l *sentryLogger) Panic(ctx context.Context, v ...interface{}) {
+	l.log(ctx, LogLevelFatal, LogSeverityFatal, fmt.Sprint(v...))
+	panic(fmt.Sprint(v...))
+}
+func (l *sentryLogger) Tracef(ctx context.Context, format string, v ...interface{}) {
+	l.log(ctx, LogLevelTrace, LogSeverityTrace, format, v...)
+}
+func (l *sentryLogger) Debugf(ctx context.Context, format string, v ...interface{}) {
+	l.log(ctx, LogLevelDebug, LogSeverityDebug, format, v...)
+}
+func (l *sentryLogger) Infof(ctx context.Context, format string, v ...interface{}) {
+	l.log(ctx, LogLevelInfo, LogSeverityInfo, format, v...)
+}
+func (l *sentryLogger) Warnf(ctx context.Context, format string, v ...interface{}) {
+	l.log(ctx, LogLevelWarn, LogSeverityWarning, format, v...)
+}
+func (l *sentryLogger) Errorf(ctx context.Context, format string, v ...interface{}) {
+	l.log(ctx, LogLevelError, LogSeverityError, format, v...)
+}
+func (l *sentryLogger) Fatalf(ctx context.Context, format string, v ...interface{}) {
+	l.log(ctx, LogLevelFatal, LogSeverityFatal, format, v...)
+	os.Exit(1)
+}
+func (l *sentryLogger) Panicf(ctx context.Context, format string, v ...interface{}) {
+	l.log(ctx, LogLevelFatal, LogSeverityFatal, format, v...)
+	panic(fmt.Sprint(v...))
+}

--- a/examples/vendor/github.com/getsentry/sentry-go/log_fallback.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/log_fallback.go
@@ -1,0 +1,65 @@
+package sentry
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/getsentry/sentry-go/attribute"
+)
+
+// Fallback, no-op logger if logging is disabled.
+type noopLogger struct{}
+
+func (*noopLogger) Trace(_ context.Context, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelTrace)
+}
+func (*noopLogger) Debug(_ context.Context, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelDebug)
+}
+func (*noopLogger) Info(_ context.Context, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
+}
+func (*noopLogger) Warn(_ context.Context, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelWarn)
+}
+func (*noopLogger) Error(_ context.Context, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelError)
+}
+func (*noopLogger) Fatal(_ context.Context, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
+	os.Exit(1)
+}
+func (*noopLogger) Panic(_ context.Context, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
+	panic(fmt.Sprintf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal))
+}
+func (*noopLogger) Tracef(_ context.Context, _ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelTrace)
+}
+func (*noopLogger) Debugf(_ context.Context, _ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelDebug)
+}
+func (*noopLogger) Infof(_ context.Context, _ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
+}
+func (*noopLogger) Warnf(_ context.Context, _ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelWarn)
+}
+func (*noopLogger) Errorf(_ context.Context, _ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelError)
+}
+func (*noopLogger) Fatalf(_ context.Context, _ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
+	os.Exit(1)
+}
+func (*noopLogger) Panicf(_ context.Context, _ string, _ ...interface{}) {
+	DebugLogger.Printf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal)
+	panic(fmt.Sprintf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelFatal))
+}
+func (*noopLogger) SetAttributes(...attribute.Builder) {
+	DebugLogger.Printf("No attributes attached. Turn on logging via EnableLogs")
+}
+func (*noopLogger) Write(_ []byte) (n int, err error) {
+	return 0, fmt.Errorf("Log with level=[%v] is being dropped. Turn on logging via EnableLogs", LogLevelInfo)
+}

--- a/examples/vendor/github.com/getsentry/sentry-go/scope.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/scope.go
@@ -302,6 +302,11 @@ func (scope *Scope) SetPropagationContext(propagationContext PropagationContext)
 	scope.propagationContext = propagationContext
 }
 
+// GetSpan returns the span from the current scope.
+func (scope *Scope) GetSpan() *Span {
+	return scope.span
+}
+
 // SetSpan sets a span for the current scope.
 func (scope *Scope) SetSpan(span *Span) {
 	scope.mu.Lock()
@@ -464,7 +469,7 @@ func (scope *Scope) ApplyToEvent(event *Event, hint *EventHint, client *Client) 
 		id := event.EventID
 		event = processor(event, hint)
 		if event == nil {
-			Logger.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
+			DebugLogger.Printf("Event dropped by one of the Scope EventProcessors: %s\n", id)
 			return nil
 		}
 	}

--- a/examples/vendor/github.com/getsentry/sentry-go/sentry.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/sentry.go
@@ -6,7 +6,7 @@ import (
 )
 
 // The version of the SDK.
-const SDKVersion = "0.32.0"
+const SDKVersion = "0.33.0"
 
 // apiVersion is the minimum version of the Sentry API compatible with the
 // sentry-go SDK.

--- a/examples/vendor/github.com/getsentry/sentry-go/span_recorder.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/span_recorder.go
@@ -24,7 +24,7 @@ func (r *spanRecorder) record(s *Span) {
 	if len(r.spans) >= maxSpans {
 		r.overflowOnce.Do(func() {
 			root := r.spans[0]
-			Logger.Printf("Too many spans: dropping spans from transaction with TraceID=%s SpanID=%s limit=%d",
+			DebugLogger.Printf("Too many spans: dropping spans from transaction with TraceID=%s SpanID=%s limit=%d",
 				root.TraceID, root.SpanID, maxSpans)
 		})
 		// TODO(tracing): mark the transaction event in some way to

--- a/examples/vendor/github.com/getsentry/sentry-go/util.go
+++ b/examples/vendor/github.com/getsentry/sentry-go/util.go
@@ -36,7 +36,7 @@ func monotonicTimeSince(start time.Time) (end time.Time) {
 	return start.Add(time.Since(start))
 }
 
-// nolint: deadcode, unused
+// nolint: unused
 func prettyPrint(data interface{}) {
 	dbg, _ := json.MarshalIndent(data, "", "  ")
 	fmt.Println(string(dbg))
@@ -62,7 +62,7 @@ func defaultRelease() (release string) {
 	}
 	for _, e := range envs {
 		if release = os.Getenv(e); release != "" {
-			Logger.Printf("Using release from environment variable %s: %s", e, release)
+			DebugLogger.Printf("Using release from environment variable %s: %s", e, release)
 			return release
 		}
 	}
@@ -89,23 +89,23 @@ func defaultRelease() (release string) {
 			if err, ok := err.(*exec.ExitError); ok && len(err.Stderr) > 0 {
 				fmt.Fprintf(&s, ": %s", err.Stderr)
 			}
-			Logger.Print(s.String())
+			DebugLogger.Print(s.String())
 		} else {
 			release = strings.TrimSpace(string(b))
-			Logger.Printf("Using release from Git: %s", release)
+			DebugLogger.Printf("Using release from Git: %s", release)
 			return release
 		}
 	}
 
-	Logger.Print("Some Sentry features will not be available. See https://docs.sentry.io/product/releases/.")
-	Logger.Print("To stop seeing this message, pass a Release to sentry.Init or set the SENTRY_RELEASE environment variable.")
+	DebugLogger.Print("Some Sentry features will not be available. See https://docs.sentry.io/product/releases/.")
+	DebugLogger.Print("To stop seeing this message, pass a Release to sentry.Init or set the SENTRY_RELEASE environment variable.")
 	return ""
 }
 
 func revisionFromBuildInfo(info *debug.BuildInfo) string {
 	for _, setting := range info.Settings {
 		if setting.Key == "vcs.revision" && setting.Value != "" {
-			Logger.Printf("Using release from debug info: %s", setting.Value)
+			DebugLogger.Printf("Using release from debug info: %s", setting.Value)
 			return setting.Value
 		}
 	}

--- a/examples/vendor/google.golang.org/grpc/internal/transport/http2_client.go
+++ b/examples/vendor/google.golang.org/grpc/internal/transport/http2_client.go
@@ -176,7 +176,7 @@ func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error
 		return fn(ctx, address)
 	}
 	if !ok {
-		networkType, address = parseDialTarget(address)
+		networkType, address = ParseDialTarget(address)
 	}
 	if opts, present := proxyattributes.Get(addr); present {
 		return proxyDial(ctx, addr, grpcUA, opts)
@@ -1242,7 +1242,8 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 			statusCode = codes.DeadlineExceeded
 		}
 	}
-	t.closeStream(s, io.EOF, false, http2.ErrCodeNo, status.Newf(statusCode, "stream terminated by RST_STREAM with error code: %v", f.ErrCode), nil, false)
+	st := status.Newf(statusCode, "stream terminated by RST_STREAM with error code: %v", f.ErrCode)
+	t.closeStream(s, st.Err(), false, http2.ErrCodeNo, st, nil, false)
 }
 
 func (t *http2Client) handleSettings(f *http2.SettingsFrame, isFirst bool) {

--- a/examples/vendor/google.golang.org/grpc/internal/transport/http_util.go
+++ b/examples/vendor/google.golang.org/grpc/internal/transport/http_util.go
@@ -439,8 +439,8 @@ func getWriteBufferPool(size int) *sync.Pool {
 	return pool
 }
 
-// parseDialTarget returns the network and address to pass to dialer.
-func parseDialTarget(target string) (string, string) {
+// ParseDialTarget returns the network and address to pass to dialer.
+func ParseDialTarget(target string) (string, string) {
 	net := "tcp"
 	m1 := strings.Index(target, ":")
 	m2 := strings.Index(target, ":/")

--- a/examples/vendor/google.golang.org/grpc/version.go
+++ b/examples/vendor/google.golang.org/grpc/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.72.0"
+const Version = "1.72.1"

--- a/examples/vendor/modules.txt
+++ b/examples/vendor/modules.txt
@@ -54,9 +54,10 @@ github.com/gabriel-vasile/mimetype
 github.com/gabriel-vasile/mimetype/internal/charset
 github.com/gabriel-vasile/mimetype/internal/json
 github.com/gabriel-vasile/mimetype/internal/magic
-# github.com/getsentry/sentry-go v0.32.0
+# github.com/getsentry/sentry-go v0.33.0
 ## explicit; go 1.21
 github.com/getsentry/sentry-go
+github.com/getsentry/sentry-go/attribute
 github.com/getsentry/sentry-go/internal/debug
 github.com/getsentry/sentry-go/internal/otel/baggage
 github.com/getsentry/sentry-go/internal/otel/baggage/internal/baggage
@@ -294,7 +295,7 @@ google.golang.org/genproto/googleapis/api/httpbody
 ## explicit; go 1.23.0
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.72.0
+# google.golang.org/grpc v1.72.1
 ## explicit; go 1.23
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
net.Listen performs a context aware side effect when resolving the passed in Addr.
We have therefore moved the creation of the net.Listener to an OnStart function in the http and grpc modules, so that this side effect is subject to the overall system start context.