### PR TITLE
Set MaxConnectionAge for our grpc servers

### DIFF
--- a/fxgrpc/grpc_server.go
+++ b/fxgrpc/grpc_server.go
@@ -229,6 +229,13 @@ func NewGrpcServer(p GrpcServerParams) (*grpc.Server, error) {
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			// See: https://github.com/grpc/grpc-go/blob/8389ddb30539e08e45391650f8c249bd8a57ffc3/internal/transport/http2_server.go#L229-L239
 			Time: time.Duration(math.MaxInt64), // Disables TCP_USER_TIMEOUT
+
+			// Tell the client to cycle the underlying tcp connection after 10 minutes.  This ensure
+			// that the client regularly issues DNS lookup, which is crucial for client that do
+			// DNS-based loadbalancing via consul SRV records.
+			// We let MaxConnectionGraceAge to its default of infinity so it'll not disrupt &
+			// shutdown long-lived http2 streams.
+			MaxConnectionAge: 10 * time.Minute,
 		}),
 	}
 	serverConf := p.Conf.GrpcServerConfig()


### PR DESCRIPTION
This setting is crucial for systems that want to use a loadbalancing mechanism that leverages consul SRV DNS records

See https://app.shortcut.com/exoscale/story/80317/nbdagent-verify-that-the-load-balancing-mecanish-correctly-recover-after-a-restart-rollout-of-block-proxy

I think it's a good default to have on stelling, because it should not cause any problem for other workloads  but will ensure that system using this loadbalancing work as expected 


[ch173311]