### PR TITLE
use a better default for buckets for metrics of request histogram

### DIFF
--- a/fxmetrics/buckets.go
+++ b/fxmetrics/buckets.go
@@ -1,0 +1,12 @@
+package fxmetrics
+
+// metricBuckets is the list of buckets used to categorize request latency
+// The more there are the more precise the p50/p9x computation can be but the more metrics are exposed.
+// We want stelling to be used in servers where requests can take between sub-ms time or several
+// seconds per request.
+var metricBuckets = []float64{
+	0.000125, 0.00025, 0.0005,
+	0.001, 0.002, 0.004, 0.008,
+	0.016, 0.032, 0.064,
+	0.128, 0.256, 0.512,
+	1.024, 2.048, 4.096, 8.192}

--- a/fxmetrics/http.go
+++ b/fxmetrics/http.go
@@ -29,7 +29,7 @@ func NewHttpMetrics() *HttpMetrics {
 		handledHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "http_server_handling_seconds",
 			Help:    "Histogram of response latency (seconds) of HTTP server requests",
-			Buckets: []float64{0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.024, 2.048, 4.096, 8.192},
+			Buckets: metricBuckets,
 		}, []string{"code", "method", "rpc_method"}),
 	}
 }

--- a/fxmetrics/metrics.go
+++ b/fxmetrics/metrics.go
@@ -111,7 +111,12 @@ const GrpcInterceptorWeight = 60
 func NewGrpcServerInterceptors(p GrpcServerInterceptorParams) (GrpcServerInterceptorsResult, error) {
 	opts := []grpc_prometheus.ServerMetricsOption{}
 	if p.Conf.MetricsConfig().Histograms {
-		opts = append(opts, grpc_prometheus.WithServerHandlingTimeHistogram(p.HistogramOps...))
+		opts = append(opts,
+			grpc_prometheus.WithServerHandlingTimeHistogram(
+				append([]grpc_prometheus.HistogramOption{
+					grpc_prometheus.WithHistogramBuckets(metricBuckets)},
+					p.HistogramOps...)...,
+			))
 	}
 	serverMetrics := grpc_prometheus.NewServerMetrics(opts...)
 	if err := p.Reg.Register(serverMetrics); err != nil {


### PR DESCRIPTION
- Align default buckets used for http & grpc 
- Lower smaller bucket from 1ms (http) or 5ms (grpc) to 0.125ms. It costs a fraction in processing power & metrics size and that way no future workload will have to care about setting their metrics buckets
(It's the values that were already used in blobd, and I want those also for the compute-topo-server)  

I tested on compute-topo-server that the default is modified and that the app using stelling can still override this default and select other buckets 