### PR TITLE
fxmetrics: handle histograms option in grpc client interceptor

### DIFF
--- a/fxmetrics/metrics.go
+++ b/fxmetrics/metrics.go
@@ -147,9 +147,26 @@ type GrpcClientInterceptorsResult struct {
 	*fxgrpc.StreamClientInterceptor `group:"stream_client_interceptor"`
 }
 
-func NewGrpcClientInterceptors(reg *prometheus.Registry) (GrpcClientInterceptorsResult, error) {
-	clientMetrics := grpc_prometheus.NewClientMetrics()
-	if err := reg.Register(clientMetrics); err != nil {
+type GrpcClientInterceptorParams struct {
+	fx.In
+
+	Conf         MetricsConfig
+	Reg          *prometheus.Registry
+	HistogramOps []grpc_prometheus.HistogramOption `optional:"true"`
+}
+
+func NewGrpcClientInterceptors(p GrpcClientInterceptorParams) (GrpcClientInterceptorsResult, error) {
+	opts := []grpc_prometheus.ClientMetricsOption{}
+	if p.Conf.MetricsConfig().Histograms {
+		opts = append(opts,
+			grpc_prometheus.WithClientHandlingTimeHistogram(
+				append([]grpc_prometheus.HistogramOption{
+					grpc_prometheus.WithHistogramBuckets(metricBuckets)},
+					p.HistogramOps...)...,
+			))
+	}
+	clientMetrics := grpc_prometheus.NewClientMetrics(opts...)
+	if err := p.Reg.Register(clientMetrics); err != nil {
 		return GrpcClientInterceptorsResult{}, err
 	}
 	return GrpcClientInterceptorsResult{


### PR DESCRIPTION
NewGrpcClientInterceptors ignores the `histograms` option unlike its server counterpart. This means metrics such as `grpc_client_handling_seconds_bucket` are not exposed even when histograms are enabled. It's a bug.
This change automatically exposes the histogram metrics just like we do for the server metrics.

Tested internally.