### PR TITLE
feat(log): Add http header fields to request logging

### DIFF
--- a/fxlogging/README.md
+++ b/fxlogging/README.md
@@ -32,6 +32,9 @@ The module lazily provides the following components:
 * WithGrpcServerInterceptorOptions and WithGrpcClientInterceptorOptions
   Allows customization of the provided grpc interceptor loggers.
   See [interceptor.Option](https://pkg.go.dev/github.com/exoscale/stelling/fxlogging/interceptor#Option)
+* WithHTTPInterceptorOptions
+  Allows customization of the provided HTTP request logger.
+  See [interceptor.HTTPOption](https://pkg.go.dev/github.com/exoscale/stelling/fxlogging/interceptor#HTTPOption)
 * WithGrpcClientInterceptors
   By default the module supplies client logging interceptors. In certain high volume cases this is not
   desirable. With this option they can be removed from the system.

--- a/fxlogging/README.md
+++ b/fxlogging/README.md
@@ -21,7 +21,7 @@ The module lazily provides the following components:
 * GrpcClientInterceptors that log all requests made with the client
 * GrpcServerInterceptors that embed a `*zap.Logger`, enriched with request metadata, in the context
 * GrpcClientInterceptors that set `peer.service` metadata, which are logged by the server
-* HttpMiddleware that logs all incoming requests on the server
+* HttpMiddleware that logs all incoming requests on the server. If present, the `x-request-id` header is logged as `request_id`.
 
 ## Options
 * WithZapOption

--- a/fxlogging/http.go
+++ b/fxlogging/http.go
@@ -15,11 +15,11 @@ type HttpMiddlewareResult struct {
 	Middleware *fxhttp.Middleware `group:"http_middleware"`
 }
 
-func NewHttpMiddleware(logger *zap.Logger) HttpMiddlewareResult {
+func NewHttpMiddleware(logger *zap.Logger, opts ...interceptor.HTTPOption) HttpMiddlewareResult {
 	return HttpMiddlewareResult{
 		Middleware: &fxhttp.Middleware{
 			Handler: func(next http.Handler) http.Handler {
-				return interceptor.NewRequestLogger(logger, next)
+				return interceptor.NewRequestLogger(logger, next, opts...)
 			},
 			Weight: 40,
 		},

--- a/fxlogging/interceptor/config.go
+++ b/fxlogging/interceptor/config.go
@@ -16,7 +16,13 @@ type interceptorConfig struct {
 	metadataFields  map[string]string
 }
 
+type httpInterceptorConfig struct {
+	headerFields map[string]string
+}
+
 type Option func(*interceptorConfig)
+
+type HTTPOption func(*httpInterceptorConfig)
 
 // WithLevelFunc provides a custom implementation that maps a gRPC status code to a logging level
 func WithLevelFunc(f func(*otelgrpc.InterceptorInfo, codes.Code) zapcore.Level) Option {
@@ -67,6 +73,15 @@ func WithMetadataFields(m map[string]string) Option {
 	}
 }
 
+// WithHTTPHeaderFields configures the HTTP request logger to extract values from
+// incoming HTTP headers and add them to the request logger. The map is
+// headerName->loggerFieldName.
+func WithHTTPHeaderFields(m map[string]string) HTTPOption {
+	return func(c *httpInterceptorConfig) {
+		c.headerFields = m
+	}
+}
+
 func newInterceptorConfig(opts []Option) *interceptorConfig {
 	conf := &interceptorConfig{
 		levelFunc:       DefaultServerCodeToLevel,
@@ -75,6 +90,18 @@ func newInterceptorConfig(opts []Option) *interceptorConfig {
 		startLogFilter:  defaultStartLogFilter,
 		extraFieldsFunc: defaultExtraFieldsFunc,
 		metadataFields:  map[string]string{},
+	}
+
+	for _, opt := range opts {
+		opt(conf)
+	}
+
+	return conf
+}
+
+func newHTTPInterceptorConfig(opts []HTTPOption) *httpInterceptorConfig {
+	conf := &httpInterceptorConfig{
+		headerFields: map[string]string{},
 	}
 
 	for _, opt := range opts {

--- a/fxlogging/interceptor/http.go
+++ b/fxlogging/interceptor/http.go
@@ -33,7 +33,8 @@ type NeverEnabler struct{}
 
 func (NeverEnabler) Enabled(zapcore.Level) bool { return false }
 
-func NewRequestLogger(logger *zap.Logger, wrapped http.Handler) http.Handler {
+func NewRequestLogger(logger *zap.Logger, wrapped http.Handler, opts ...HTTPOption) http.Handler {
+	conf := newHTTPInterceptorConfig(opts)
 	logger = logger.WithOptions(zap.WithCaller(false), zap.AddStacktrace(NeverEnabler{}))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -63,6 +64,12 @@ func NewRequestLogger(logger *zap.Logger, wrapped http.Handler) http.Handler {
 
 		if rpcMethod := fxhttp.RPCMethodFromContext(ctx); rpcMethod != "" {
 			fields = append(fields, zap.String("rpc.method", rpcMethod))
+		}
+
+		for headerName, fieldName := range conf.headerFields {
+			if value := r.Header.Get(headerName); value != "" && fieldName != "" {
+				fields = append(fields, zap.String(fieldName, value))
+			}
 		}
 
 		l := logger.With(fields...)

--- a/fxlogging/interceptor/http.go
+++ b/fxlogging/interceptor/http.go
@@ -66,6 +66,10 @@ func NewRequestLogger(logger *zap.Logger, wrapped http.Handler, opts ...HTTPOpti
 			fields = append(fields, zap.String("rpc.method", rpcMethod))
 		}
 
+		if requestID := r.Header.Get("x-request-id"); requestID != "" {
+			fields = append(fields, zap.String("request_id", requestID))
+		}
+
 		for headerName, fieldName := range conf.headerFields {
 			if value := r.Header.Get(headerName); value != "" && fieldName != "" {
 				fields = append(fields, zap.String(fieldName, value))

--- a/fxlogging/interceptor/http_test.go
+++ b/fxlogging/interceptor/http_test.go
@@ -1,0 +1,85 @@
+package interceptor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func withTestRequestLogger(t *testing.T, cb func(handler http.Handler, logs *observer.ObservedLogs), opts ...HTTPOption) {
+	t.Helper()
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WrapCore(func(_ zapcore.Core) zapcore.Core { return core })))
+
+	handler := NewRequestLogger(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		LoggerFromContext(r.Context()).Info("handler log")
+		w.WriteHeader(http.StatusAccepted)
+	}), opts...)
+
+	cb(handler, logs)
+}
+
+func TestRequestLogger(t *testing.T) {
+	t.Run("Should enrich logger with headerFields", func(t *testing.T) {
+		rid := uuid.NewString()
+		run := func(handler http.Handler, logs *observer.ObservedLogs) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("x-request-id", rid)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			require.NotEmpty(t, rr.Header().Get("X-Trace-Id"))
+
+			handlerLog := requireLogMessage(t, logs.AllUntimed(), "handler log")
+			require.Contains(t, handlerLog.ContextMap(), "request_id")
+			require.Equal(t, rid, handlerLog.ContextMap()["request_id"])
+
+			requestLog := requireLogMessage(t, logs.AllUntimed(), "Handled request")
+			require.Contains(t, requestLog.ContextMap(), "request_id")
+			require.Equal(t, rid, requestLog.ContextMap()["request_id"])
+		}
+		headerFields := map[string]string{
+			"x-request-id": "request_id",
+		}
+		withTestRequestLogger(t, run, WithHTTPHeaderFields(headerFields))
+	})
+
+	t.Run("Should not enrich logger when configured header is missing", func(t *testing.T) {
+		run := func(handler http.Handler, logs *observer.ObservedLogs) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			handlerLog := requireLogMessage(t, logs.AllUntimed(), "handler log")
+			require.NotContains(t, handlerLog.ContextMap(), "request_id")
+
+			requestLog := requireLogMessage(t, logs.AllUntimed(), "Handled request")
+			require.NotContains(t, requestLog.ContextMap(), "request_id")
+		}
+		headerFields := map[string]string{
+			"x-request-id": "request_id",
+		}
+		withTestRequestLogger(t, run, WithHTTPHeaderFields(headerFields))
+	})
+}
+
+func requireLogMessage(t *testing.T, entries []observer.LoggedEntry, message string) observer.LoggedEntry {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Message == message {
+			return entry
+		}
+	}
+	require.Failf(t, "missing log message", "message %q was not logged", message)
+	return observer.LoggedEntry{}
+}

--- a/fxlogging/interceptor/http_test.go
+++ b/fxlogging/interceptor/http_test.go
@@ -1,6 +1,7 @@
 package interceptor
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -28,10 +29,10 @@ func withTestRequestLogger(t *testing.T, cb func(handler http.Handler, logs *obs
 }
 
 func TestRequestLogger(t *testing.T) {
-	t.Run("Should enrich logger with headerFields", func(t *testing.T) {
+	t.Run("Should enrich logger with request id header", func(t *testing.T) {
 		rid := uuid.NewString()
 		run := func(handler http.Handler, logs *observer.ObservedLogs) {
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 			req.Header.Set("x-request-id", rid)
 			rr := httptest.NewRecorder()
 
@@ -47,15 +48,35 @@ func TestRequestLogger(t *testing.T) {
 			require.Contains(t, requestLog.ContextMap(), "request_id")
 			require.Equal(t, rid, requestLog.ContextMap()["request_id"])
 		}
+		withTestRequestLogger(t, run)
+	})
+
+	t.Run("Should enrich logger with headerFields", func(t *testing.T) {
+		rid := uuid.NewString()
+		run := func(handler http.Handler, logs *observer.ObservedLogs) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
+			req.Header.Set("x-correlation-id", rid)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			handlerLog := requireLogMessage(t, logs.AllUntimed(), "handler log")
+			require.Contains(t, handlerLog.ContextMap(), "correlation_id")
+			require.Equal(t, rid, handlerLog.ContextMap()["correlation_id"])
+
+			requestLog := requireLogMessage(t, logs.AllUntimed(), "Handled request")
+			require.Contains(t, requestLog.ContextMap(), "correlation_id")
+			require.Equal(t, rid, requestLog.ContextMap()["correlation_id"])
+		}
 		headerFields := map[string]string{
-			"x-request-id": "request_id",
+			"x-correlation-id": "correlation_id",
 		}
 		withTestRequestLogger(t, run, WithHTTPHeaderFields(headerFields))
 	})
 
-	t.Run("Should not enrich logger when configured header is missing", func(t *testing.T) {
+	t.Run("Should not enrich logger when request id header is missing", func(t *testing.T) {
 		run := func(handler http.Handler, logs *observer.ObservedLogs) {
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 			rr := httptest.NewRecorder()
 
 			handler.ServeHTTP(rr, req)
@@ -66,10 +87,7 @@ func TestRequestLogger(t *testing.T) {
 			requestLog := requireLogMessage(t, logs.AllUntimed(), "Handled request")
 			require.NotContains(t, requestLog.ContextMap(), "request_id")
 		}
-		headerFields := map[string]string{
-			"x-request-id": "request_id",
-		}
-		withTestRequestLogger(t, run, WithHTTPHeaderFields(headerFields))
+		withTestRequestLogger(t, run)
 	})
 }
 

--- a/fxlogging/logging.go
+++ b/fxlogging/logging.go
@@ -39,6 +39,10 @@ func NewModule(conf LoggingConfig, opts ...Option) fx.Option {
 				fx.ResultTags(`group:"unary_server_interceptor"`, `group:"stream_server_interceptor"`),
 			),
 			fx.Annotate(
+				NewHttpMiddleware,
+				fx.ParamTags(``, `group:"logging_http_interceptor_options"`),
+			),
+			fx.Annotate(
 				NewGrpcInjectLoggerInterceptors,
 				fx.ParamTags(``, `group:"inject_logger_interceptor_options"`),
 				fx.ResultTags(`group:"unary_server_interceptor"`, `group:"stream_server_interceptor"`),
@@ -47,7 +51,6 @@ func NewModule(conf LoggingConfig, opts ...Option) fx.Option {
 				NewGrpcInjectPeerInterceptors,
 				fx.ResultTags(`group:"unary_client_interceptor"`, `group:"stream_client_interceptor"`),
 			),
-			NewHttpMiddleware,
 		),
 		fx.Supply(
 			fx.Private,
@@ -55,6 +58,7 @@ func NewModule(conf LoggingConfig, opts ...Option) fx.Option {
 			fx.Annotate(modConf.zapOptions, fx.ResultTags(`group:"zap_opts,flatten"`)),
 			fx.Annotate(modConf.grpcServerInterceptorOptions, fx.ResultTags(`group:"logging_server_interceptor_options,flatten"`)),
 			fx.Annotate(modConf.grpcClientInterceptorOptions, fx.ResultTags(`group:"logging_client_interceptor_options,flatten"`)),
+			fx.Annotate(modConf.httpInterceptorOptions, fx.ResultTags(`group:"logging_http_interceptor_options,flatten"`)),
 		),
 	)
 

--- a/fxlogging/option.go
+++ b/fxlogging/option.go
@@ -11,6 +11,7 @@ type moduleConfig struct {
 	zapOptions                   []zap.Option
 	grpcServerInterceptorOptions []interceptor.Option
 	grpcClientInterceptorOptions []interceptor.Option
+	httpInterceptorOptions       []interceptor.HTTPOption
 	enableGrpcClientInterceptors bool
 }
 
@@ -50,5 +51,11 @@ func WithGrpcServerInterceptorOptions(opt interceptor.Option) Option {
 func WithGrpcClientInterceptorOptions(opt interceptor.Option) Option {
 	return func(mc *moduleConfig) {
 		mc.grpcClientInterceptorOptions = append(mc.grpcClientInterceptorOptions, opt)
+	}
+}
+
+func WithHTTPInterceptorOptions(opt interceptor.HTTPOption) Option {
+	return func(mc *moduleConfig) {
+		mc.httpInterceptorOptions = append(mc.httpInterceptorOptions, opt)
 	}
 }


### PR DESCRIPTION
Adds default HTTP request logging support for x-request-id, recording it as request_id when present. Adds also configurable HTTP header-to-log-field support for other headers via `WithHTTPHeaderFields`, preserves existing behavior when headers are absent or no options are configured.