### PR TITLE
feat(authorizer): Add configuration for an IdP endpoint

### DIFF
--- a/fxauthorizer/README.md
+++ b/fxauthorizer/README.md
@@ -23,7 +23,9 @@ This provides a flexible environment that allows expressing a wide variety of po
 
 ## Configuration file
 The module supports the following configuration options:
+
 * `Rule`: The CEL expression which will be validated for each request. Required
+* `IdpEndpoint`: The IdP server which signs the JWTs we should trust. The server needs to expose the OIDC .well-known endpoint. Optional
 
 ## Request schema
 While most parameters are shared between HTTP and gRPC requests, they have been tailored to their respective

--- a/fxauthorizer/authorizer.go
+++ b/fxauthorizer/authorizer.go
@@ -11,35 +11,16 @@ import (
 )
 
 type moduleOpts struct {
-	tokenExtractorConfig  *tokenExtractorConfig
-	tokenExtractorOptions []oidc.TokenExtractorOption
+	requireToken bool
 }
 
 type moduleOption func(*moduleOpts)
 
-// WithTokenExtractor will populate the request.jwt field with the IDToken produced by an
-// oidc.TokenExtractor built from the given identity provider URL and client ID.
-// If requireToken is set, the request will be denied if token extraction fails, without evaluating the policy
-// If requireToken is false, JWT will be nil if token extraction fails and the policy will be evaluated
-func WithTokenExtractor(requireToken bool, identityProviderUrl string, clientId string, opts ...oidc.TokenExtractorOption) moduleOption {
+// WithRequireJWT sets whether the presence of a JWT in the Authorization header is required for auth-z
+func WithRequireJWT(requireToken bool) moduleOption {
 	return func(o *moduleOpts) {
-		o.tokenExtractorConfig = &tokenExtractorConfig{
-			identityProviderUrl: identityProviderUrl,
-			clientId:            clientId,
-			requireToken:        requireToken,
-		}
-		o.tokenExtractorOptions = opts
+		o.requireToken = requireToken
 	}
-}
-
-// tokenExtractorConfig bundles the parameters needed to build the oidc.TokenExtractor so they can
-// be threaded through fx as a single optional dependency. NewGrpcAuthorizer/NewHttpAuthorizer each
-// build their own extractor instance from it. The TokenExtractorOptions travel separately, through
-// the authorizer_oidc_token_extractor_option group, and are collected back up via ParamTags.
-type tokenExtractorConfig struct {
-	identityProviderUrl string
-	clientId            string
-	requireToken        bool
 }
 
 // NewModule provides authorization middleware to the system:
@@ -49,34 +30,16 @@ type tokenExtractorConfig struct {
 // distinct, but share the same config.
 // If you need different rules for either protocol, you must supply
 // 2 different configurations with proper annotations to your system
-func NewModule(conf AuthorizerConfig, opts ...moduleOption) fx.Option {
-	modOpts := &moduleOpts{}
-	for _, o := range opts {
-		o(modOpts)
+func NewModule(conf AuthorizerConfig, modOpts ...moduleOption) fx.Option {
+	options := &moduleOpts{}
+	for _, o := range modOpts {
+		o(options)
 	}
 
-	supplyOpts := fx.Options()
-	if modOpts.tokenExtractorConfig != nil {
-		supplyOpts = fx.Options(
-			fx.Supply(
-				fx.Private,
-				modOpts.tokenExtractorConfig,
-				// Threading the TokenExtractorOptions through a group lets us hand them to the
-				// variadic teOpts parameter of NewGrpcAuthorizer/NewHttpAuthorizer below via ParamTags
-				fx.Annotate(
-					modOpts.tokenExtractorOptions,
-					fx.ResultTags(`group:"authorizer_oidc_token_extractor_option,flatten"`),
-				),
-			),
-		)
-	}
-
-	return fx.Module(
-		"authorizer",
-		supplyOpts,
+	opts := fx.Options(
 		fx.Provide(
-			fx.Annotate(NewGrpcAuthorizer, fx.ParamTags(``, `optional:"true"`, `group:"authorizer_oidc_token_extractor_option"`)),
-			fx.Annotate(NewHttpAuthorizer, fx.ParamTags(``, `optional:"true"`, `group:"authorizer_oidc_token_extractor_option"`)),
+			fx.Annotate(NewGrpcAuthorizer, fx.ParamTags(``, `group:"authorizer_option"`)),
+			fx.Annotate(NewHttpAuthorizer, fx.ParamTags(``, `group:"authorizer_option"`)),
 			fx.Annotate(
 				NewGrpcAuthorizerServerInterceptors,
 				fx.ResultTags(`group:"unary_server_interceptor"`, `group:"stream_server_interceptor"`),
@@ -85,8 +48,23 @@ func NewModule(conf AuthorizerConfig, opts ...moduleOption) fx.Option {
 		),
 		fx.Supply(
 			fx.Annotate(conf, fx.As(new(AuthorizerConfig))),
+			tokenRequired(options.requireToken),
 			fx.Private,
 		),
+	)
+
+	if conf.AuthorizerConfig().IdpEndpoint != "" {
+		opts = fx.Options(
+			opts,
+			fx.Provide(
+				fx.Annotate(newTokenExtractor, fx.ResultTags(`group:"authorizer_option"`)),
+			),
+		)
+	}
+
+	return fx.Module(
+		"authorizer",
+		opts,
 	)
 }
 
@@ -98,33 +76,30 @@ type AuthorizerConfig interface {
 type Authorizer struct {
 	// The CEL expression that will be evaluated for each request made to the server
 	Rule string `validate:"required"`
-	// TODO: Add oidc options when we need them
+	// The URL where we can find the IdP that signs trusted JWTs
+	IdpEndpoint string `validate:"url"`
 }
 
 func (a *Authorizer) AuthorizerConfig() *Authorizer {
 	return a
 }
 
-func NewGrpcAuthorizer(conf AuthorizerConfig, te *tokenExtractorConfig, teOpts ...oidc.TokenExtractorOption) (interceptor.GrpcAuthorizer, error) {
-	if te == nil {
-		return interceptor.NewGrpcAuthorizer(conf.AuthorizerConfig().Rule)
-	}
-	extractor, err := oidc.NewTokenExtractor(te.identityProviderUrl, te.clientId, teOpts...)
+type tokenRequired bool
+
+func newTokenExtractor(conf AuthorizerConfig, tokenRequired tokenRequired) (interceptor.AuthorizerOption, error) {
+	extractor, err := oidc.NewTokenExtractor(conf.AuthorizerConfig().IdpEndpoint, "", oidc.WithSkipClientIDCheck())
 	if err != nil {
 		return nil, err
 	}
-	return interceptor.NewGrpcAuthorizer(conf.AuthorizerConfig().Rule, interceptor.WithTokenExtractor(extractor, te.requireToken))
+	return interceptor.WithTokenExtractor(extractor, bool(tokenRequired)), nil
 }
 
-func NewHttpAuthorizer(conf AuthorizerConfig, te *tokenExtractorConfig, teOpts ...oidc.TokenExtractorOption) (interceptor.HttpAuthorizer, error) {
-	if te == nil {
-		return interceptor.NewHttpAuthorizer(conf.AuthorizerConfig().Rule)
-	}
-	extractor, err := oidc.NewTokenExtractor(te.identityProviderUrl, te.clientId, teOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return interceptor.NewHttpAuthorizer(conf.AuthorizerConfig().Rule, interceptor.WithTokenExtractor(extractor, te.requireToken))
+func NewGrpcAuthorizer(conf AuthorizerConfig, opts ...interceptor.AuthorizerOption) (interceptor.GrpcAuthorizer, error) {
+	return interceptor.NewGrpcAuthorizer(conf.AuthorizerConfig().Rule, opts...)
+}
+
+func NewHttpAuthorizer(conf AuthorizerConfig, opts ...interceptor.AuthorizerOption) (interceptor.HttpAuthorizer, error) {
+	return interceptor.NewHttpAuthorizer(conf.AuthorizerConfig().Rule, opts...)
 }
 
 // Setting this late in the chain so observability interceptors can monitor requests that fail authorization

--- a/fxauthorizer/authorizer_example_test.go
+++ b/fxauthorizer/authorizer_example_test.go
@@ -12,7 +12,6 @@ import (
 
 	sconfig "github.com/exoscale/stelling/config"
 	"github.com/exoscale/stelling/fxauthorizer"
-	"github.com/exoscale/stelling/fxauthorizer/oidc"
 	"github.com/exoscale/stelling/fxgrpc"
 	"github.com/exoscale/stelling/fxgrpc/health"
 	"github.com/exoscale/stelling/fxhttp"
@@ -111,7 +110,7 @@ func Example_grpc() {
 	// Grpc metadata keys are always lowercased, so we point the extractor at "authorization" rather than the HTTP-style "Authorization"
 	conf := &GrpcConfig{}
 	rule := "request.service == 'grpc.health.v1.Health' && 'trusted-group' in request.jwt.groups"
-	args := []string{"authorizer-test", "--authorizer.rule", rule, "--server.address", "localhost:8080", "--client.endpoint", "localhost:8080", "--client.insecure-connection"}
+	args := []string{"authorizer-test", "--authorizer.idp-endpoint", idp.server.URL, "--authorizer.rule", rule, "--server.address", "localhost:8080", "--client.endpoint", "localhost:8080", "--client.insecure-connection"}
 	if err := sconfig.Load(conf, args); err != nil {
 		panic(err)
 	}
@@ -124,9 +123,9 @@ func Example_grpc() {
 		fxgrpc.NewServerModule(conf),
 		fxgrpc.NewClientModule(conf),
 		health.Module,
-		fxauthorizer.NewModule(conf, fxauthorizer.WithTokenExtractor(
-			false, idp.server.URL, "", oidc.WithSkipClientIDCheck(), oidc.WithAuthHeader("authorization"))),
+		fxauthorizer.NewModule(conf),
 		fx.Provide(
+			// zap.NewDevelopment,
 			zap.NewNop,
 			NewRouteGuideServer,
 			pb.NewRouteGuideClient,
@@ -180,7 +179,7 @@ func Example_http() {
 
 	conf := &HttpConfig{}
 	rule := "request.path == '/health' || 'trusted-group' in request.jwt.groups"
-	args := []string{"authorizer-test", "--authorizer.rule", rule, "--server.address", "localhost:8081"}
+	args := []string{"authorizer-test", "--authorizer.rule", rule, "--authorizer.idp-endpoint", idp.server.URL, "--server.address", "localhost:8081"}
 	if err := sconfig.Load(conf, args); err != nil {
 		panic(err)
 	}
@@ -191,8 +190,7 @@ func Example_http() {
 		// Suppressing fx logs to ensure deterministic output
 		fx.WithLogger(func() fxevent.Logger { return fxevent.NopLogger }),
 		fxhttp.NewModule(conf),
-		fxauthorizer.NewModule(conf, fxauthorizer.WithTokenExtractor(
-			false, idp.server.URL, "", oidc.WithSkipClientIDCheck())),
+		fxauthorizer.NewModule(conf),
 		fx.Provide(
 			zap.NewNop,
 			newMux,

--- a/fxauthorizer/oidc/oidc.go
+++ b/fxauthorizer/oidc/oidc.go
@@ -29,7 +29,7 @@ func WithSkipClientIDCheck() TokenExtractorOption {
 // By default the 'Authorization' header is used
 func WithAuthHeader(header string) TokenExtractorOption {
 	return func(te *TokenExtractor) {
-		te.header = header
+		te.header = http.CanonicalHeaderKey(header)
 	}
 }
 
@@ -75,6 +75,7 @@ func (te *TokenExtractor) Extract(ctx context.Context, md map[string][]string) (
 	if md == nil {
 		return nil, fmt.Errorf("no metadata to extract token from")
 	}
+	md = canonicalizeHeaders(md)
 	authHeader := md[te.header]
 	if len(authHeader) == 0 {
 		return nil, fmt.Errorf("authorization header '%s' is missing", te.header)
@@ -89,4 +90,14 @@ func (te *TokenExtractor) Extract(ctx context.Context, md map[string][]string) (
 		return nil, fmt.Errorf("invalid token: %w", err)
 	}
 	return parsedToken, nil
+}
+
+// canonicalizeHeaders ensures all headers are in the canonical format used by net/http
+// This is useful in a grpc context which returns headers as lowercase
+func canonicalizeHeaders(input map[string][]string) map[string][]string {
+	output := make(map[string][]string, len(input))
+	for k, v := range input {
+		output[http.CanonicalHeaderKey(k)] = v
+	}
+	return output
 }


### PR DESCRIPTION
In order for JWTs to be validated and parsed, we need to have the keys of IdP that signed them.

We add a runtime configuration parameter for the IdP endpoint. This is server needs to support the OIDC .well-known endpoints so we can obtain the keys.

This is the minimum information required to make things work, and keeps implementation details such as the TokenExtractor outside of the users scope.