### PR TITLE
renovate: disable gha version management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,11 @@
   "extends": [
     "config:recommended",
     "docker:pinDigests",
-    "helpers:pinGitHubActionDigests",
-    "customManagers:dockerfileVersions",
-    "customManagers:githubActionsVersions"
+    "customManagers:dockerfileVersions"
   ],
+  "github-actions": {
+    "enabled": false
+  },
   "schedule": ["after 8am and before 5pm every weekday"],
   "minimumReleaseAge": "3 days",
   "labels": [


### PR DESCRIPTION
This is now taken over by XIP171 and the gha-pins bot.